### PR TITLE
fix: can_retry() always returns False; broaden rate limit detection

### DIFF
--- a/src/claude_code_queue/claude_interface.py
+++ b/src/claude_code_queue/claude_interface.py
@@ -123,7 +123,9 @@ class ClaudeCodeInterface:
         # Common rate limit patterns
         rate_limit_patterns = [
             ("usage limit reached", self._extract_reset_time_from_limit_message),
+            ("usage limit", self._extract_reset_time_from_limit_message),
             ("rate limit exceeded", self._estimate_reset_time),
+            ("rate limit", self._estimate_reset_time),
             ("too many requests", self._estimate_reset_time),
             ("quota exceeded", self._estimate_reset_time),
             ("limit exceeded", self._estimate_reset_time),

--- a/src/claude_code_queue/models.py
+++ b/src/claude_code_queue/models.py
@@ -46,10 +46,7 @@ class QueuedPrompt:
 
     def can_retry(self) -> bool:
         """Check if this prompt can be retried."""
-        return (self.max_retries == -1 or self.retry_count < self.max_retries) and self.status in [
-            PromptStatus.FAILED,
-            PromptStatus.RATE_LIMITED,
-        ]
+        return self.max_retries == -1 or self.retry_count < self.max_retries
 
     def should_execute_now(self) -> bool:
         """Check if this prompt should be executed now (not rate limited)."""

--- a/src/claude_code_queue/models.py
+++ b/src/claude_code_queue/models.py
@@ -46,7 +46,7 @@ class QueuedPrompt:
 
     def can_retry(self) -> bool:
         """Check if this prompt can be retried."""
-        return self.retry_count < self.max_retries and self.status in [
+        return (self.max_retries == -1 or self.retry_count < self.max_retries) and self.status in [
             PromptStatus.FAILED,
             PromptStatus.RATE_LIMITED,
         ]
@@ -107,6 +107,7 @@ class QueueState:
     failed_count: int = 0
     rate_limited_count: int = 0
     current_rate_limit: Optional[RateLimitInfo] = None
+    global_rate_limit_until: Optional[datetime] = None
 
     def get_next_prompt(self) -> Optional[QueuedPrompt]:
         """Get the next prompt to execute (highest priority, can execute now)."""

--- a/src/claude_code_queue/storage.py
+++ b/src/claude_code_queue/storage.py
@@ -148,6 +148,11 @@ class QueueStorage:
                         data["last_processed"]
                     )
 
+                if data.get("global_rate_limit_until"):
+                    state.global_rate_limit_until = datetime.fromisoformat(
+                        data["global_rate_limit_until"]
+                    )
+
             except Exception as e:
                 print(f"Error loading queue state: {e}")
 
@@ -166,6 +171,10 @@ class QueueStorage:
                 "rate_limited_count": state.rate_limited_count,
                 "last_processed": (
                     state.last_processed.isoformat() if state.last_processed else None
+                ),
+                "global_rate_limit_until": (
+                    state.global_rate_limit_until.isoformat()
+                    if state.global_rate_limit_until else None
                 ),
                 "updated_at": datetime.now().isoformat(),
             }


### PR DESCRIPTION
## Summary

Two bugs that prevented unlimited retries (`max_retries: -1`) from working:

- **`can_retry()` always returned `False`** — The method checked `self.status in [FAILED, RATE_LIMITED]`, but `_process_execution_result` calls it while `prompt.status` is still `EXECUTING`. This made every failing job permanently fail after one attempt regardless of `max_retries`. Fix: remove the status guard; the count check alone is sufficient.

- **Rate limit misclassified as regular failure** — `_detect_rate_limit()` matched only exact strings like `"usage limit reached"` and `"rate limit exceeded"`. Claude Code emits variations that didn't match, so usage-limited jobs fell through as regular failures (no retry cooldown, counted against retry budget). Fix: add broader `"usage limit"` and `"rate limit"` patterns that catch more message variants.

## Test plan

- [ ] Set `max_retries: -1` on a job that fails on the first attempt; confirm it re-queues instead of moving to `failed/`
- [ ] Simulate a rate-limit response containing `"rate limit"` (without `" exceeded"`); confirm it is classified as rate-limited, not a regular failure
- [ ] Confirm jobs with `max_retries: 3` still stop retrying after 3 attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)