### PR TITLE
fix(c3): recover orphaned EXECUTING tasks and clean stale .executing.md on QUEUED save

### DIFF
--- a/src/claude_code_queue/storage.py
+++ b/src/claude_code_queue/storage.py
@@ -187,7 +187,8 @@ class QueueStorage:
         for file_path in self.queue_dir.glob("*.executing.md"):
             prompt = self.parser.parse_prompt_file(file_path)
             if prompt:
-                prompt.status = PromptStatus.EXECUTING
+                prompt.status = PromptStatus.QUEUED
+                prompt.add_log("Recovered: execution was interrupted. Re-queuing.")
                 prompts.append(prompt)
                 processed_ids.add(prompt.id)
 
@@ -242,6 +243,7 @@ class QueueStorage:
                 self._remove_prompt_files(prompt.id, self.queue_dir)
             else:  # QUEUED
                 target_dir = self.queue_dir
+                self._remove_prompt_files(prompt.id, self.queue_dir)
             file_path = target_dir / base_filename
             return self.parser.write_prompt_file(prompt, file_path)
         except Exception as e:


### PR DESCRIPTION
## Bug Report

Two related bugs in `storage.py` both cause tasks to become permanently stuck as `EXECUTING`, from which they never recover.

---

### Bug 1 — Stale `.executing.md` survives every QUEUED save

**Location:** `storage.py:221–249` (`_save_single_prompt()`, QUEUED branch at line 243)

`_save_single_prompt()` calls `_remove_prompt_files()` for every status — EXECUTING, RATE_LIMITED, COMPLETED, FAILED, CANCELLED — **except QUEUED**:

\`\`\`python
elif prompt.status == PromptStatus.EXECUTING:
    self._remove_prompt_files(prompt.id, self.queue_dir)  # ✓ cleans old files

elif prompt.status == PromptStatus.RATE_LIMITED:
    self._remove_prompt_files(prompt.id, self.queue_dir)  # ✓ cleans old files

else:  # QUEUED
    target_dir = self.queue_dir
    # ← NO _remove_prompt_files() call. Old .executing.md stays on disk.
\`\`\`

Every time a task is reset to QUEUED (via retry, `_shutdown()`, or any other transition), the old `.executing.md` is left on disk alongside the newly written `.md`.

`_load_prompts_from_files()` loads `.executing.md` first (Pass 1) and claims the prompt ID. The `.md` file is then skipped in Pass 3 because the ID is already in `processed_ids`. The prompt is loaded as `EXECUTING`. `get_next_prompt()` only picks up `QUEUED` tasks — so the orphan is silently skipped every tick, forever.

**Every graceful shutdown (Ctrl+C / SIGTERM) that occurs while a task is in flight guarantees the task will be permanently lost on the next run.**

**Fix:** add `_remove_prompt_files()` in the QUEUED branch. One-line change, mirrors every other branch.

---

### Bug 2 — Orphaned `.executing.md` files never recovered on startup

**Location:** `storage.py:187–192` (`_load_prompts_from_files()`, Pass 1)

If the queue daemon is killed ungracefully (SIGKILL, OOM, system crash) while a task is running, the `.executing.md` file remains on disk. On the next startup:

\`\`\`python
for file_path in self.queue_dir.glob("*.executing.md"):
    prompt = self.parser.parse_prompt_file(file_path)
    if prompt:
        prompt.status = PromptStatus.EXECUTING   # ← loaded as EXECUTING
        processed_ids.add(prompt.id)
\`\`\`

`get_next_prompt()` only considers `QUEUED` tasks. `_check_rate_limited_prompts()` only touches `RATE_LIMITED` tasks. There is no code path that processes in-memory `EXECUTING` prompts outside of an active execution. The orphaned task is silently skipped every tick and accumulates across restarts — it will never execute again without manual file deletion.

**Every crash permanently loses any in-flight task.**

At startup, we know the previous process is gone. Any `.executing.md` file therefore represents an interrupted execution, and it is always safe to re-queue it.

**Fix:** change `prompt.status = PromptStatus.EXECUTING` to `prompt.status = PromptStatus.QUEUED` in the `.executing.md` glob pass, and add a log entry recording the recovery.

---

### Interaction with each other

Bug 1 is actually the trigger that exposes Bug 2 repeatedly: even if a user manually recovers from a crash, the next graceful shutdown re-creates the stale `.executing.md` that Bug 2 would then load as stuck-EXECUTING on the following startup.

Both bugs must be fixed together for the system to be reliable across restarts.

---

### At-least-once execution note

Fix 2 introduces **at-least-once execution semantics**: a task that completed successfully but whose result was not saved to disk before a crash will re-run on the next startup. Users with non-idempotent tasks should design them to be safe to run more than once.

## Test plan

- [ ] Kill queue with `kill -9` mid-task, restart — task is re-queued with "Recovered" log entry
- [ ] Ctrl+C mid-task, restart — no duplicate `.executing.md` left behind; task runs cleanly
- [ ] Failing task with retry — no duplicate files accumulate across retries
- [ ] Normal completion — still works; completed tasks move to `completed/` as before
- [ ] Multiple crash/restart cycles — orphaned files do not accumulate

## Related bugs (separate PRs)

This fix is a prerequisite for the retry logic fixes (C1, C2) — without it, any successfully re-queued retry would recreate stale `.executing.md` files on the next QUEUED save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)