### PR TITLE
fix(c1): remove incorrect status guard from can_retry(); add max_retries=-1 support

### DIFF
--- a/src/claude_code_queue/models.py
+++ b/src/claude_code_queue/models.py
@@ -46,10 +46,9 @@ class QueuedPrompt:
 
     def can_retry(self) -> bool:
         """Check if this prompt can be retried."""
-        return self.retry_count < self.max_retries and self.status in [
-            PromptStatus.FAILED,
-            PromptStatus.RATE_LIMITED,
-        ]
+        if self.max_retries == -1:
+            return True
+        return self.retry_count < self.max_retries
 
     def should_execute_now(self) -> bool:
         """Check if this prompt should be executed now (not rate limited)."""

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -154,8 +154,9 @@ class QueueManager:
         """Execute a single prompt."""
         prompt.status = PromptStatus.EXECUTING
         prompt.last_executed = datetime.now()
+        max_label = "∞" if prompt.max_retries == -1 else str(prompt.max_retries)
         prompt.add_log(
-            f"Started execution (attempt {prompt.retry_count + 1}/{prompt.max_retries})"
+            f"Started execution (attempt {prompt.retry_count + 1}/{max_label})"
         )
 
         self.storage.save_queue_state(self.state)


### PR DESCRIPTION
## Bug Report

Two bugs in `models.py` make the entire retry system dead code for non-rate-limited failures.

---

### Bug C1 — `can_retry()` always returns False in the failure path

**Location:** `models.py:47–52` (`can_retry()`), `queue_manager.py:196–216` (`_process_execution_result()`)

\`\`\`python
# models.py
def can_retry(self) -> bool:
    return self.retry_count < self.max_retries and self.status in [
        PromptStatus.FAILED,
        PromptStatus.RATE_LIMITED,
    ]
\`\`\`

\`\`\`python
# queue_manager.py — _process_execution_result(), failure branch
else:
    prompt.retry_count += 1
    if prompt.can_retry():          # ← called while status is EXECUTING
        prompt.status = PromptStatus.QUEUED
    else:
        prompt.status = PromptStatus.FAILED
        self.state.failed_count += 1
\`\`\`

`_execute_prompt()` sets `prompt.status = EXECUTING` before calling Claude. `_process_execution_result()` is called immediately after, before the status has been changed to anything else. At that point:

```
prompt.status == EXECUTING
EXECUTING in [FAILED, RATE_LIMITED] → False
can_retry() → False (regardless of retry_count vs max_retries)
```

**The `if prompt.can_retry()` branch is dead code.** It is never reached. Every non-rate-limited failure unconditionally takes the `else` branch and sets `prompt.status = FAILED`, immediately and permanently, on the very first failure.

`max_retries` has zero effect on non-rate-limited errors. Any transient failure — network blip, Claude process crash, timeout — permanently kills the task.

The status check is correct in one place: `_check_rate_limited_prompts()`, which only calls `can_retry()` when `prompt.status == RATE_LIMITED`. The fix is to remove it from `can_retry()` itself, which is called from multiple contexts.

---

### Bug S2 — `max_retries=-1` (unlimited) actually disables all retries

**Location:** `models.py:49`

\`\`\`python
return self.retry_count < self.max_retries ...
\`\`\`

With `max_retries=-1`: `N < -1` is always `False`. The documented "unlimited retries" value (`-1`) does the opposite: it disables all retries entirely. A user setting `max_retries: -1` gets zero retries.

---

### Fix

\`\`\`python
def can_retry(self) -> bool:
    if self.max_retries == -1:
        return True
    return self.retry_count < self.max_retries
\`\`\`

Remove the status guard. Add `-1` special case for unlimited retries. The rest of `_process_execution_result()` is structurally correct and becomes live automatically once `can_retry()` returns the right value.

Also update the `_execute_prompt()` log message to display `"∞"` instead of `"-1"` for unlimited retries.

---

### Deployment note

This fix must be merged with the C2 rate-limit persistence fix (which persists `retry_count` across reloads). Without C2, `retry_count` resets to 0 on every tick (state is reloaded each iteration), making `max_retries` effectively unenforceable.

## Test plan

- [ ] Task fails transiently — retries up to `max_retries` times, then FAILED
- [ ] `max_retries: 1` — one attempt, no retries (matches documented semantics)
- [ ] `max_retries: -1` — retries indefinitely until success
- [ ] Attempt counter in execution log shows `"1/∞"` for unlimited, `"1/3"` for finite
- [ ] Rate-limited tasks still recover correctly (existing behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)