### PR TITLE
fix(s5): correct off-by-one-hour reset time estimate for hours 20-23

### DIFF
--- a/src/claude_code_queue/claude_interface.py
+++ b/src/claude_code_queue/claude_interface.py
@@ -193,7 +193,7 @@ class ClaudeCodeInterface:
             next_reset = now.replace(hour=20, minute=0, second=0, microsecond=0)
         else:
             next_reset = (now + timedelta(days=1)).replace(
-                hour=0, minute=0, second=0, microsecond=0
+                hour=1, minute=0, second=0, microsecond=0
             )
 
         if next_reset <= now:


### PR DESCRIPTION
## Bug Report

`_estimate_reset_time()` in `claude_interface.py` returns an incorrect reset time for rate limits that occur between 20:00 and 23:59.

---

### The bug

**Location:** `claude_interface.py:193–197` (`_estimate_reset_time()`, `else` branch)

The function maps the current hour to the next 5-hour window boundary:

\`\`\`python
if hour < 5:
    next_reset = now.replace(hour=5, ...)   # window 00-05 → next boundary 05:00
elif hour < 10:
    next_reset = now.replace(hour=10, ...)  # window 05-10 → next boundary 10:00
elif hour < 15:
    next_reset = now.replace(hour=15, ...)  # window 10-15 → next boundary 15:00
elif hour < 20:
    next_reset = now.replace(hour=20, ...)  # window 15-20 → next boundary 20:00
else:
    next_reset = (now + timedelta(days=1)).replace(
        hour=0, ...                         # window 20-01 → BUG: returns 00:00, not 01:00
    )
\`\`\`

The 5-hour windows are: 00–05, 05–10, 10–15, 15–20, **20–01** (the last window wraps past midnight). The correct boundary after 20:00 is `20 + 5 = 25 hours → 01:00 next day`. The code returns `00:00` (midnight) instead.

For a rate limit occurring at e.g. 22:00, the code estimates a 2-hour wait (until midnight) when the actual wait is 3 hours (until 01:00 next day). The queue retries up to an hour too early, burns a retry attempt, and gets rate-limited again.

---

### Fix

Change `hour=0` to `hour=1` in the `else` branch. One-character change. No other branches are affected.

## Test plan

- [ ] At 22:00, `_estimate_reset_time()` returns 01:00 next day (3-hour wait), not midnight (2-hour wait)
- [ ] At 20:00, returns 01:00 next day (5-hour wait)
- [ ] At 23:59, returns 01:00 next day (~1-hour wait)
- [ ] At 19:59 (just before the else branch), returns 20:00 same day (existing behaviour unchanged)
- [ ] All other window boundaries (05:00, 10:00, 15:00, 20:00) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)