### PR TITLE
docs(phase6): correct rate limit description, max_retries semantics, execution log, at-least-once warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,14 +254,15 @@ The prompt box is built with Rust for fast file indexing and responsive UI, maki
 
 1. **Queue Processing**: Runs prompts in priority order (lower number = higher priority)
 2. **Rate Limit Detection**: Monitors Claude Code output for rate limit messages
-3. **Automatic Waiting**: When rate limited, waits for the next 5-hour window
-4. **Retry Logic**: Failed prompts are retried up to `max_retries` times
+3. **Automatic Waiting**: When rate limited, parses the actual reset time from Claude's output when available; falls back to estimating the next 5-hour window boundary otherwise
+4. **Retry Logic**: Failed prompts are retried up to `max_retries` total attempts. Interrupted prompts (from crashes or ungraceful shutdowns) are automatically re-queued on the next startup — **at-least-once semantics apply**: a task that finished but whose result was not saved before a crash will run again. Design tasks to be idempotent where possible.
 5. **File Organization**:
     - `~/.claude-queue/queue/` - Pending prompts
     - `~/.claude-queue/completed/` - Successful executions
     - `~/.claude-queue/failed/` - Failed prompts
     - `~/.claude-queue/bank/` - Saved template library
     - `~/.claude-queue/queue-state.json` - Queue metadata
+6. **Execution Logs**: After each execution attempt, a log is appended to the prompt's `.md` file for human inspection. The log is automatically stripped before the prompt is sent to Claude, so Claude always receives only the original prompt text regardless of how many times the task has been retried.
 
 ## Configuration
 
@@ -289,10 +290,12 @@ working_directory: /path/to/project # Where to run the prompt
 context_files: # Files to include as context
     - src/main.py
     - README.md
-max_retries: 3 # Maximum retry attempts
+max_retries: 3 # Maximum total execution attempts (1 = no retries, -1 = unlimited)
 estimated_tokens: 1000 # Estimated token usage (optional)
 ---
 ```
+
+**`max_retries` semantics:** this field controls the total number of execution attempts, not the number of retries after the first failure. `max_retries: 3` means 3 total attempts (initial + 2 retries); `max_retries: 1` means a single attempt with no retries; `max_retries: -1` means unlimited retries. Rate-limited executions and failure retries share the same counter.
 
 ## Examples
 
@@ -366,8 +369,10 @@ The system automatically detects Claude Code rate limits by monitoring:
 When rate limited:
 
 1. Prompt status changes to `rate_limited`
-2. Naively loop every fixed interval until rate limit is lifted (there's probably a way smarter way to find the end time of rate limit window， open to contributions)
-3. Once the rate limit is lifted, continue processing the requests
+2. The queue determines the reset time using a two-tier strategy:
+    - **Parsed reset time**: extracts the actual reset time from Claude's output when available
+    - **Estimated reset time**: falls back to estimating the next 5-hour window boundary (00:00–05:00, 05:00–10:00, 10:00–15:00, 15:00–20:00, 20:00–01:00) based on the current time
+3. Once the reset time is reached, the prompt is re-queued and execution resumes
 
 ## Troubleshooting
 
@@ -383,9 +388,13 @@ claude-queue status --detailed
 
 **Prompts stuck in executing state:**
 
--   Stop queue processor (Ctrl+C)
--   Restart with `claude-queue start`
--   Executing prompts will reset to queued status
+Interrupted prompts are **automatically re-queued** on the next startup — no manual intervention is needed. Simply restart the queue:
+
+```bash
+claude-queue start
+```
+
+> **Warning — at-least-once execution:** If the daemon was killed after Claude finished but before the result was saved to disk, the task will run again on restart. Design tasks to be idempotent (safe to run more than once) where possible.
 
 **Rate limit not detected:**
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tool to queue Claude Code prompts and automatically execute them when token li
 -   **Markdown-based Queue**: Each prompt is a `.md` file with YAML frontmatter
 -   **Automatic Rate Limit Handling**: Detects rate limits and waits for reset windows
 -   **Priority System**: Execute high-priority prompts first
--   **Retry Logic**: Automatically retry failed prompts
+-   **Retry Logic**: Automatically retry failed and rate-limited prompts; both share the `max_retries` total-attempts counter
 -   **Persistent Storage**: Queue survives system restarts
 -   **Prompt Bank**: Save and reuse templates for recurring tasks
 -   **Interactive Prompt Box**: Browse and select files interactively with fuzzy search


### PR DESCRIPTION
## Summary

Documentation-only changes to `README.md`. No code is modified. Corrects four accuracy gaps.

**Merge order:** This PR must not be merged before the C4 fix (execution log sentinel). Fix 6c (execution log note) only applies once the sentinel stripping is in place.

---

### Fix 6a — Rate limit behaviour description

The "Automatic Waiting" bullet said "waits for the next 5-hour window". The "Rate Limit Handling" section described a "naive loop every fixed interval" and included "there's probably a smarter way… open to contributions".

The actual implementation uses a two-tier strategy:
1. Parse the actual reset time from Claude's output when available.
2. Fall back to estimating the next 5-hour window boundary from the current time.

Both locations are updated to describe this correctly, and the outdated note is removed.

---

### Fix 6b — `max_retries` semantics and `-1` value

The YAML comment said `# Maximum retry attempts` (ambiguous) and `max_retries: -1` was not documented.

- YAML comment updated to `# Maximum total execution attempts (1 = no retries, -1 = unlimited)`.
- Prose note added: `max_retries` counts **total attempts**, not retries after the first failure. `max_retries: 3` → 3 total attempts (2 retries); `max_retries: 1` → no retries; `max_retries: -1` → unlimited.
- Notes that rate-limited and failure retries share the same counter.

---

### Fix 6c — Execution log in `.md` files

A new "Execution Logs" item added to How It Works explaining that the log is appended for human inspection but stripped before the prompt is sent to Claude — Claude always receives only the original prompt text.

---

### Fix 6d — At-least-once execution semantics

The "Prompts stuck in executing state" troubleshooting entry told users to manually stop and restart. With the C3 fix, interrupted prompts are automatically re-queued on startup.

- Entry rewritten to explain automatic re-queuing.
- Blockquote warning added: tasks may run more than once if the daemon was killed after Claude finished but before the result was saved. Recommends idempotent task design.
- At-least-once note also added to the Retry Logic bullet in How It Works.

## Test plan

- [ ] Read through the updated How It Works section — all 6 bullets are accurate
- [ ] Check the Rate Limit Handling section — two-tier strategy described, no outdated notes remain
- [ ] Verify the `max_retries` YAML comment and prose note match actual behaviour
- [ ] Confirm the "Prompts stuck in executing state" entry reflects automatic re-queuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)