### PR TITLE
fix: security hardening, thread-safe execution, and rate-limit detection improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,8 @@ package-dir = {"" = "src"}
 target = "prompt-box"
 path = "claude-prompt-box/Cargo.toml"
 
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-mock>=3.0"]
+
 [project.scripts]
 claude-queue = "claude_code_queue.cli:main"

--- a/src/claude_code_queue/claude_interface.py
+++ b/src/claude_code_queue/claude_interface.py
@@ -2,8 +2,10 @@
 Interface for executing prompts via Claude Code CLI.
 """
 
-import os
+import re
+import shutil
 import subprocess
+import sys
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -12,17 +14,44 @@ from typing import Optional, List, Tuple
 from .models import ExecutionResult, RateLimitInfo, QueuedPrompt
 
 
+# Rate-limit messages are written to stderr (not stdout) from this version onward.
+_STDERR_RATE_LIMIT_MIN_VERSION = (2, 1, 50)
+
+# Maximum hours into the future a rate-limit reset time may be set.
+# Guards against a malicious or buggy claude binary stalling the queue indefinitely.
+_RATE_LIMIT_MAX_RESET_HOURS = 24
+
+# S11b — Only scan this many characters of stderr for rate-limit patterns.
+# Genuine rate-limit messages from the Claude CLI are short (≤ ~200 chars) and
+# appear at the start of stderr. A depth cap prevents a subprocess tool whose
+# stderr happens to contain a rate-limit phrase from triggering false positives.
+# Value is in Unicode code points (Python string characters); for the ASCII-only
+# CLI output this equals the byte count.
+_RATE_LIMIT_SCAN_CHARS = 2048
+
+
 class ClaudeCodeInterface:
     """Interface for executing prompts via Claude Code CLI."""
 
-    def __init__(self, claude_command: str = "claude", timeout: int = 3600):
+    def __init__(self, claude_command: str = "claude", timeout: int = 3600,
+                 skip_permissions: bool = True):
         self.claude_command = claude_command
         self.timeout = timeout
+        self.skip_permissions = skip_permissions
         self._verify_claude_available()
 
     def _verify_claude_available(self) -> None:
         """Verify Claude Code CLI is available."""
         try:
+            # SC4 Mitigation 3 — If the command is a bare name (not an absolute path),
+            # resolve it once at startup using shutil.which() and store the absolute path.
+            # Subsequent calls use the absolute path, preventing PATH hijacking between
+            # startup and execution. # SC4
+            if not Path(self.claude_command).is_absolute():
+                resolved = shutil.which(self.claude_command)
+                if resolved:
+                    self.claude_command = resolved
+
             result = subprocess.run(
                 [self.claude_command, "--version"],
                 capture_output=True,
@@ -31,6 +60,23 @@ class ClaudeCodeInterface:
             )
             if result.returncode != 0:
                 raise RuntimeError(f"Claude Code CLI not available: {result.stderr}")
+
+            # R3 — Warn if the installed claude version predates stderr-only rate-limit
+            # detection. Older versions may write rate-limit messages to stdout, which
+            # would be missed after the R3 change.
+            version_str = result.stdout.strip()  # e.g. "2.1.50 (Claude Code)"
+            match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)
+            if match:
+                installed = tuple(int(x) for x in match.groups())
+                if installed < _STDERR_RATE_LIMIT_MIN_VERSION:
+                    print(
+                        f"Warning: claude {version_str!r} predates stderr-only rate-limit "
+                        f"detection (threshold "
+                        f"{'.'.join(str(x) for x in _STDERR_RATE_LIMIT_MIN_VERSION)}). "
+                        "Rate-limit messages written to stdout will be missed.",
+                        file=sys.stderr,
+                    )
+
         except FileNotFoundError:
             raise RuntimeError(
                 f"Claude Code CLI not found. Make sure '{self.claude_command}' is in PATH."
@@ -43,26 +89,43 @@ class ClaudeCodeInterface:
         start_time = time.time()
 
         try:
-            original_cwd = os.getcwd()
-
             working_dir = Path(prompt.working_directory).resolve()
+
+            # SC2 — Warn if working_directory is outside the user's home directory.
+            # Mitigates path traversal via YAML-controlled working_directory field.
+            # Validation happens BEFORE mkdir() so no directory is created silently.
+            # Path.home() raises RuntimeError on containers or headless systems where
+            # $HOME is unset; the second except clause skips the check in that case.
+            try:
+                home = Path.home()
+                working_dir.relative_to(home)
+            except ValueError:
+                print(
+                    f"Warning: working_directory {working_dir} is outside home directory "
+                    f"({home}). Proceeding with caution.",
+                    file=sys.stderr,
+                )
+            except RuntimeError:
+                pass  # home directory not determinable; skip the check
+
             if not working_dir.exists():
                 working_dir.mkdir(parents=True, exist_ok=True)
 
-            os.chdir(working_dir)
-
-            cmd = [
-                self.claude_command,
-                "--print",
-                "--dangerously-skip-permissions",
-            ]  # Use --print for non-interactive output and skip permissions
+            # SC1 — Build command conditionally based on skip_permissions setting.
+            cmd = [self.claude_command, "--print"]
+            if self.skip_permissions:
+                cmd.append("--dangerously-skip-permissions")
 
             full_prompt = prompt.content
 
             if prompt.context_files:
                 context_refs = []
                 for context_file in prompt.context_files:
-                    context_path = Path(context_file)  # Relative to working directory
+                    # E1 — Resolve context paths against working_dir so the
+                    # Python-side exists() guard works correctly for relative paths.
+                    # Before E1 (os.chdir), relative paths resolved against the
+                    # changed CWD; now we must be explicit.
+                    context_path = working_dir / context_file
                     if context_path.exists():
                         context_refs.append(f"@{context_file}")
 
@@ -71,15 +134,22 @@ class ClaudeCodeInterface:
 
             cmd.append(full_prompt)
 
+            # E1 — Use cwd= instead of os.chdir() to set the subprocess working directory.
+            # This is thread-safe: os.chdir() changes the entire process CWD, which breaks
+            # concurrent executions and any other thread that relies on getcwd().
             result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=self.timeout
+                cmd, capture_output=True, text=True, timeout=self.timeout,
+                cwd=str(working_dir)
             )
-
-            os.chdir(original_cwd)
 
             execution_time = time.time() - start_time
 
-            rate_limit_info = self._detect_rate_limit(result.stdout + result.stderr)
+            # R3 — Rate-limit messages from the claude CLI appear on stderr, not stdout.
+            # Searching stdout causes false positives if Claude's response happens to
+            # contain any trigger phrase (e.g., code that handles rate limits).
+            # Caveat: if older versions of the `claude` CLI write rate-limit messages to
+            # stdout, this change will miss them (see _STDERR_RATE_LIMIT_MIN_VERSION).
+            rate_limit_info = self._detect_rate_limit(result.stderr)
 
             success = result.returncode == 0 and not rate_limit_info.is_rate_limited
 
@@ -92,10 +162,6 @@ class ClaudeCodeInterface:
             )
 
         except subprocess.TimeoutExpired:
-            try:
-                os.chdir(original_cwd)
-            except:
-                pass
             execution_time = time.time() - start_time
             return ExecutionResult(
                 success=False,
@@ -104,10 +170,6 @@ class ClaudeCodeInterface:
                 execution_time=execution_time,
             )
         except Exception as e:
-            try:
-                os.chdir(original_cwd)
-            except:
-                pass
             execution_time = time.time() - start_time
             return ExecutionResult(
                 success=False,
@@ -118,19 +180,27 @@ class ClaudeCodeInterface:
 
     def _detect_rate_limit(self, output: str) -> RateLimitInfo:
         """Detect rate limiting from Claude Code output."""
-        output_lower = output.lower()
+        # S11b: restrict pattern scan to the first _RATE_LIMIT_SCAN_CHARS characters.
+        # Genuine rate-limit messages from the Claude CLI are short and always appear
+        # near the start of stderr. This prevents false positives from rate-limit-like
+        # phrases buried in long tool or subprocess output.
+        # The reset_extractor and limit_message still use the full output string.
+        scan_window = output[:_RATE_LIMIT_SCAN_CHARS].lower()
 
-        # Common rate limit patterns
+        # S11a: 'limit exceeded' removed — too broad (matches Python tracebacks, shell
+        # ulimit errors, compiler output, etc.). Every meaningful Claude CLI rate-limit
+        # scenario is covered by the remaining four patterns.
+        # ASSUMPTION: the Claude CLI never uses bare "api limit exceeded" without a
+        # "rate", "quota", or "usage" qualifier. Re-verify if CLI output format changes.
         rate_limit_patterns = [
             ("usage limit reached", self._extract_reset_time_from_limit_message),
             ("rate limit exceeded", self._estimate_reset_time),
             ("too many requests", self._estimate_reset_time),
             ("quota exceeded", self._estimate_reset_time),
-            ("limit exceeded", self._estimate_reset_time),
         ]
 
         for pattern, reset_extractor in rate_limit_patterns:
-            if pattern in output_lower:
+            if pattern in scan_window:
                 reset_time = reset_extractor(output)
                 return RateLimitInfo(
                     is_rate_limited=True,
@@ -144,13 +214,13 @@ class ClaudeCodeInterface:
     def _extract_reset_time_from_limit_message(self, output: str) -> Optional[datetime]:
         """Extract reset time from Claude's limit message."""
         try:
-            import re
-
             pattern1 = r"usage limit reached\|(\d+)"
             match1 = re.search(pattern1, output, re.IGNORECASE)
             if match1:
                 timestamp = int(match1.group(1))
-                return datetime.fromtimestamp(timestamp)
+                return ClaudeCodeInterface._cap_reset_time(
+                    datetime.fromtimestamp(timestamp)
+                )
 
             pattern2 = (
                 r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)"
@@ -171,7 +241,9 @@ class ClaudeCodeInterface:
                         continue
 
                 if latest_time:
-                    return latest_time + timedelta(hours=5)
+                    return ClaudeCodeInterface._cap_reset_time(
+                        latest_time + timedelta(hours=5)
+                    )
 
         except Exception as e:
             print(f"Error parsing reset time: {e}")
@@ -191,15 +263,30 @@ class ClaudeCodeInterface:
             next_reset = now.replace(hour=15, minute=0, second=0, microsecond=0)
         elif hour < 20:
             next_reset = now.replace(hour=20, minute=0, second=0, microsecond=0)
-        else:
+        else:  # hour >= 20 → next 5-hour boundary is 01:00 next day
             next_reset = (now + timedelta(days=1)).replace(
-                hour=0, minute=0, second=0, microsecond=0
+                hour=1, minute=0, second=0, microsecond=0
             )
 
         if next_reset <= now:
             next_reset += timedelta(hours=5)
 
-        return next_reset
+        # SC4 — Cap to prevent a malicious/buggy claude binary from stalling the queue.
+        max_reset = datetime.now() + timedelta(hours=_RATE_LIMIT_MAX_RESET_HOURS)
+        return min(next_reset, max_reset)
+
+    @staticmethod
+    def _cap_reset_time(dt: datetime) -> datetime:
+        """Cap reset time to at most _RATE_LIMIT_MAX_RESET_HOURS from now.
+
+        Also strips timezone info so the returned datetime is always naive,
+        consistent with the rest of the codebase. Without stripping, comparing a
+        timezone-aware parsed ISO timestamp (e.g. "...+00:00") against naive
+        datetime.now() raises TypeError.
+        """
+        naive_dt = dt.replace(tzinfo=None)
+        max_reset = datetime.now() + timedelta(hours=_RATE_LIMIT_MAX_RESET_HOURS)
+        return min(naive_dt, max_reset)
 
     def test_connection(self) -> Tuple[bool, str]:
         """Test if Claude Code is working."""

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -21,9 +21,11 @@ class QueueManager:
         claude_command: str = "claude",
         check_interval: int = 30,
         timeout: int = 3600,
+        skip_permissions: bool = True,
     ):
         self.storage = QueueStorage(storage_dir)
-        self.claude_interface = ClaudeCodeInterface(claude_command, timeout)
+        self.claude_interface = ClaudeCodeInterface(claude_command, timeout,
+                                                    skip_permissions=skip_permissions)
         self.check_interval = check_interval
         self.running = False
         self.state: Optional[QueueState] = None

--- a/src/claude_code_queue/storage.py
+++ b/src/claude_code_queue/storage.py
@@ -5,6 +5,7 @@ Queue storage system with markdown support.
 import json
 import re
 import shutil
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
@@ -39,8 +40,57 @@ class MarkdownPromptParser:
             if frontmatter.strip():
                 try:
                     metadata = yaml.safe_load(frontmatter) or {}
-                except yaml.YAMLError:
+                except yaml.YAMLError as e:
+                    print(
+                        f"Warning: YAML parse error in {file_path}, using defaults: {e}",
+                        file=sys.stderr,
+                    )
                     metadata = {}
+
+            # R6 / Fix 3b — Strip execution log from content before assigning to prompt.
+            #
+            # Primary: split on the unique HTML sentinel (robust, no collision risk).
+            # Fallback: legacy "## Execution Log" format written before sentinel was
+            # introduced.
+            #
+            # WARNING — separator collision: if the user's prompt content contains the
+            # literal separator string, the split will fire early. This is an inherent
+            # limitation of the inline-separator markdown format. maxsplit=1 prevents
+            # multiple splits but cannot distinguish content-embedded separators.
+            SENTINEL = "\n\n<!-- claude-queue:execution-log -->"
+            LOG_SEPARATOR = "\n\n## Execution Log\n"
+
+            if SENTINEL in markdown_content:
+                # Primary path: split on the HTML sentinel.
+                prompt_content = markdown_content.split(SENTINEL, 1)[0].strip()
+                prompt_execution_log = ""  # log section not loaded back into memory
+            elif LOG_SEPARATOR in markdown_content:
+                # Fallback path: legacy format (no sentinel).
+                content_part, log_part = markdown_content.split(LOG_SEPARATOR, 1)
+                # Strip the fenced code block wrapper written by write_prompt_file().
+                # Use rfind() for the closing fence instead of endswith() so the parser
+                # is robust to execution_log values that lack a trailing "\n" (e.g. a
+                # whitespace-only log). write_prompt_file() writes the closing "```"
+                # immediately after the log content with no intervening newline in that
+                # case, so endswith("\n```") would silently fail and leave the fence
+                # markers in prompt_execution_log.
+                log_stripped = log_part.strip()
+                if log_stripped.startswith("```\n"):
+                    inner = log_stripped[4:]          # remove opening "```\n" fence marker
+                    close = inner.rfind("\n```")
+                    if close >= 0:
+                        log_body = inner[:close].strip()
+                    else:
+                        # No closing fence on its own line — graceful fallback: strip
+                        # any trailing backticks left over from the malformed block.
+                        log_body = inner.rstrip("`").strip()
+                else:
+                    log_body = log_stripped
+                prompt_content = content_part.strip()
+                prompt_execution_log = log_body
+            else:
+                prompt_content = markdown_content
+                prompt_execution_log = ""
 
             prompt_id = (
                 file_path.stem.split("-", 1)[0]
@@ -48,15 +98,41 @@ class MarkdownPromptParser:
                 else file_path.stem
             )
 
+            # R5 — Type-safe coercion for retry_count. YAML parses "retry_count: 3"
+            # correctly as int, but a hand-edited value like "retry_count: three" or
+            # "retry_count: 1.5" would pass a non-int into the dataclass, causing a
+            # TypeError later when retry_count < max_retries is evaluated.
+            try:
+                retry_count = int(metadata.get("retry_count", 0))
+            except (ValueError, TypeError):
+                retry_count = 0
+
             prompt = QueuedPrompt(
                 id=prompt_id,
-                content=markdown_content,
+                content=prompt_content,
+                execution_log=prompt_execution_log,
                 working_directory=metadata.get("working_directory", "."),
                 priority=metadata.get("priority", 0),
                 context_files=metadata.get("context_files", []),
                 max_retries=metadata.get("max_retries", 3),
+                retry_count=retry_count,
                 estimated_tokens=metadata.get("estimated_tokens"),
-                created_at=datetime.fromtimestamp(file_path.stat().st_ctime),
+                # R5 — Restore created_at from YAML; fall back to filesystem ctime.
+                # Using ctime alone causes created_at to drift when files are copied or
+                # their timestamps change. The YAML value is the authoritative source.
+                created_at=(
+                    QueueStorage._parse_optional_datetime(metadata.get("created_at"))
+                    or datetime.fromtimestamp(file_path.stat().st_ctime)
+                ),
+                last_executed=QueueStorage._parse_optional_datetime(
+                    metadata.get("last_executed")
+                ),
+                rate_limited_at=QueueStorage._parse_optional_datetime(
+                    metadata.get("rate_limited_at")
+                ),
+                reset_time=QueueStorage._parse_optional_datetime(
+                    metadata.get("reset_time")
+                ),
             )
 
             return prompt
@@ -101,34 +177,74 @@ class MarkdownPromptParser:
                     f.write(prompt.execution_log)
                     f.write("```\n")
 
-            return True
-
         except Exception as e:
             print(f"Error writing prompt file {file_path}: {e}")
             return False
 
+        # SC3 — chmod is OUTSIDE the outer try — the file write already succeeded.
+        # A filesystem that doesn't support permission bits (FAT, some NFS mounts)
+        # must not cause write_prompt_file() to return False.
+        try:
+            file_path.chmod(0o600)
+        except Exception as chmod_err:
+            print(
+                f"Warning: could not set permissions on {file_path}: {chmod_err}",
+                file=sys.stderr,
+            )
+        return True   # write succeeded regardless of chmod outcome
+
     @staticmethod
     def get_base_filename(prompt: QueuedPrompt) -> str:
         """Get the base filename for a prompt (id and sanitized title, no status suffix)."""
-        sanitized_title = QueueStorage._sanitize_filename_static(prompt.content[:50])
+        # R2 — Guard against empty content to prevent filenames like "{id}-.md".
+        sanitized_title = QueueStorage._sanitize_filename_static(prompt.content[:50]) or "no-title"
         return f"{prompt.id}-{sanitized_title}.md"
 
 
 class QueueStorage:
     """Manages queue storage using markdown files and JSON state."""
 
-    def __init__(self, base_dir: str = "~/.claude-queue"):
-        self.base_dir = Path(base_dir).expanduser()
+    def __init__(self, storage_dir: str = "~/.claude-queue"):
+        self.base_dir = Path(storage_dir).expanduser()
         self.queue_dir = self.base_dir / "queue"
         self.completed_dir = self.base_dir / "completed"
         self.failed_dir = self.base_dir / "failed"
         self.bank_dir = self.base_dir / "bank"
         self.state_file = self.base_dir / "queue-state.json"
 
+        # SC3 — Use unconditional chmod() after each mkdir() to ensure both new and
+        # existing directories are restricted, regardless of umask. mkdir(mode=...) is
+        # silently ignored when exist_ok=True and the directory already exists.
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir.chmod(0o700)
         for dir_path in [self.queue_dir, self.completed_dir, self.failed_dir, self.bank_dir]:
             dir_path.mkdir(parents=True, exist_ok=True)
+            dir_path.chmod(0o700)
 
         self.parser = MarkdownPromptParser()
+
+    @staticmethod
+    def _parse_optional_datetime(val) -> Optional[datetime]:
+        """Parse an ISO datetime string, returning None on any error.
+
+        Always returns a naive datetime (tzinfo stripped) so comparisons against
+        datetime.now() never raise TypeError. The existing
+        _extract_reset_time_from_limit_message() can produce timezone-aware
+        datetimes (e.g. from ISO strings ending in Z or +00:00); those get
+        written to YAML via .isoformat() and must be normalised on read-back.
+
+        The Z-suffix substitution handles Python < 3.11, where
+        datetime.fromisoformat() does not accept the trailing "Z" character.
+        Python 3.11+ accepts "Z" natively, but the substitution is harmless there.
+        """
+        if not val:
+            return None
+        try:
+            if isinstance(val, str) and val.endswith("Z"):
+                val = val[:-1] + "+00:00"
+            return datetime.fromisoformat(val).replace(tzinfo=None)
+        except (ValueError, TypeError):
+            return None
 
     def load_queue_state(self) -> QueueState:
         """Load queue state from storage."""
@@ -187,7 +303,12 @@ class QueueStorage:
         for file_path in self.queue_dir.glob("*.executing.md"):
             prompt = self.parser.parse_prompt_file(file_path)
             if prompt:
-                prompt.status = PromptStatus.EXECUTING
+                # Fix 1c — At-least-once semantics: if the process crashed while
+                # executing a prompt, the .executing.md file is left on disk.
+                # Re-queue the prompt so it runs again on restart rather than
+                # leaving it permanently stuck in EXECUTING state.
+                prompt.status = PromptStatus.QUEUED
+                prompt.add_log("Recovered from interrupted execution (process restart)")
                 prompts.append(prompt)
                 processed_ids.add(prompt.id)
 
@@ -222,16 +343,17 @@ class QueueStorage:
         """Save a single prompt to the appropriate location."""
         try:
             base_filename = MarkdownPromptParser.get_base_filename(prompt)
+            cross_dir = False  # will be set True for moves out of queue_dir
             if prompt.status == PromptStatus.COMPLETED:
                 target_dir = self.completed_dir
-                self._remove_prompt_files(prompt.id, self.queue_dir)
+                cross_dir = True
             elif prompt.status == PromptStatus.FAILED:
                 target_dir = self.failed_dir
-                self._remove_prompt_files(prompt.id, self.queue_dir)
+                cross_dir = True
             elif prompt.status == PromptStatus.CANCELLED:
                 target_dir = self.failed_dir
                 base_filename = f"{prompt.id}-cancelled.md"
-                self._remove_prompt_files(prompt.id, self.queue_dir)
+                cross_dir = True
             elif prompt.status == PromptStatus.EXECUTING:
                 target_dir = self.queue_dir
                 base_filename = base_filename.replace(".md", ".executing.md")
@@ -242,29 +364,40 @@ class QueueStorage:
                 self._remove_prompt_files(prompt.id, self.queue_dir)
             else:  # QUEUED
                 target_dir = self.queue_dir
+                # Fix 1b — Remove any stale .executing.md or .rate-limited.md file
+                # left over from a previous run that crashed before transitioning.
+                # Without this, the orphaned file is picked up on reload as EXECUTING,
+                # causing the retried QUEUED file to be ignored.
+                self._remove_prompt_files(prompt.id, self.queue_dir)
             file_path = target_dir / base_filename
-            return self.parser.write_prompt_file(prompt, file_path)
+            success = self.parser.write_prompt_file(prompt, file_path)
+            # FT-007 — For cross-directory moves (COMPLETED/FAILED/CANCELLED) delete
+            # the queue-dir source file AFTER the destination write succeeds.
+            # Deleting before writing risks permanent data loss if the write fails.
+            # At-least-once caveat: a crash between write-success and unlink leaves
+            # the prompt in both directories; load_queue_state will re-enqueue it.
+            if cross_dir and success:
+                self._remove_prompt_files(prompt.id, self.queue_dir)
+            return success
         except Exception as e:
             print(f"Error saving prompt {prompt.id}: {e}")
             return False
 
     def _remove_prompt_files(self, prompt_id: str, directory: Path) -> None:
         """Remove all files for a prompt ID from a directory, including any status suffixes."""
-        patterns = [
-            f"{prompt_id}.md",
-            f"{prompt_id}*.md",
-        ]
-        for pattern in patterns:
-            for file_path in directory.glob(pattern):
-                try:
-                    file_path.unlink()
-                except Exception as e:
-                    print(f"Error removing file {file_path}: {e}")
-        for file_path in directory.glob(f"{prompt_id}-#*.md"):
+        # E2 — {prompt_id}-*.md matches every variant the storage layer can write:
+        # {id}-title.md, {id}-title.executing.md, {id}-title.rate-limited.md, and
+        # the hard-coded {id}-cancelled.md. The `-` separator is mandatory:
+        # get_base_filename() always produces `{id}-{title}.md` (falling back to
+        # `{id}-no-title.md`), so no prompt file is ever written without a `-`
+        # after the ID. Using `{id}*.md` (no separator) would collide with any
+        # prompt whose ID is a prefix of another (e.g. removing "abc1" would also
+        # delete "abc12345-task.md").
+        for file_path in directory.glob(f"{prompt_id}-*.md"):
             try:
                 file_path.unlink()
             except Exception as e:
-                print(f"Error removing processed file {file_path}: {e}")
+                print(f"Error removing file {file_path}: {e}")
 
     @staticmethod
     def _sanitize_filename_static(text: str) -> str:
@@ -310,14 +443,38 @@ Any additional context or requirements...
 What should be delivered...
 """
 
-        file_path = self.queue_dir / f"{filename}.md"
+        # FT-042 — Sanitize the caller-supplied filename before constructing the path.
+        # Path(filename).name strips any leading directory components (e.g. "../../x"
+        # becomes "x"), preventing writes outside queue_dir.
+        # _sanitize_filename_static then removes invalid filesystem characters.
+        safe_name = QueueStorage._sanitize_filename_static(Path(filename).name)
+        if not safe_name:
+            raise ValueError(f"Invalid template filename: {filename!r}")
+        file_path = self.queue_dir / f"{safe_name}.md"
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(template_content)
+
+        # SC3 — Restrict template file permissions.
+        try:
+            file_path.chmod(0o600)
+        except Exception as chmod_err:
+            print(
+                f"Warning: could not set permissions on {file_path}: {chmod_err}",
+                file=sys.stderr,
+            )
 
         return file_path
 
     def save_prompt_to_bank(self, template_name: str, priority: int = 0) -> Path:
         """Save a prompt template to the bank directory."""
+        # FT-043 — Sanitize before building the f-string; safe_name is referenced
+        # inside template_content below so it must be computed first.
+        # Path(template_name).name strips directory traversal components;
+        # _sanitize_filename_static removes invalid filesystem characters.
+        safe_name = QueueStorage._sanitize_filename_static(Path(template_name).name)
+        if not safe_name:
+            raise ValueError(f"Invalid bank template name: {template_name!r}")
+
         template_content = f"""---
 priority: {priority}
 working_directory: .
@@ -326,7 +483,7 @@ max_retries: 3
 estimated_tokens: null
 ---
 
-# {template_name.replace('-', ' ').replace('_', ' ').title()}
+# {safe_name.replace('-', ' ').replace('_', ' ').title()}
 
 Write your prompt here...
 
@@ -336,22 +493,31 @@ Any additional context or requirements...
 ## Expected Output
 What should be delivered...
 """
-        
-        file_path = self.bank_dir / f"{template_name}.md"
+
+        file_path = self.bank_dir / f"{safe_name}.md"
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(template_content)
-        
+
+        # SC3 — Restrict bank template file permissions.
+        try:
+            file_path.chmod(0o600)
+        except Exception as chmod_err:
+            print(
+                f"Warning: could not set permissions on {file_path}: {chmod_err}",
+                file=sys.stderr,
+            )
+
         return file_path
 
     def list_bank_templates(self) -> List[dict]:
         """List all templates in the bank directory."""
         templates = []
-        
+
         for file_path in self.bank_dir.glob("*.md"):
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     content = f.read()
-                
+
                 # Parse frontmatter to get metadata
                 metadata = {}
                 if content.startswith("---\n"):
@@ -361,16 +527,18 @@ What should be delivered...
                             metadata = yaml.safe_load(parts[1]) or {}
                         except yaml.YAMLError:
                             pass
-                
+
                 # Extract title from content or use filename
                 title = file_path.stem.replace('-', ' ').replace('_', ' ').title()
-                if len(parts) >= 3:
-                    lines = parts[2].strip().split('\n')
-                    for line in lines:
-                        if line.startswith('# '):
-                            title = line[2:].strip()
-                            break
-                
+                if content.startswith("---\n"):
+                    parts = content.split("---\n", 2)
+                    if len(parts) >= 3:
+                        lines = parts[2].strip().split('\n')
+                        for line in lines:
+                            if line.startswith('# '):
+                                title = line[2:].strip()
+                                break
+
                 templates.append({
                     'name': file_path.stem,
                     'title': title,
@@ -379,26 +547,26 @@ What should be delivered...
                     'estimated_tokens': metadata.get('estimated_tokens'),
                     'modified': datetime.fromtimestamp(file_path.stat().st_mtime)
                 })
-            
+
             except Exception as e:
                 print(f"Error reading template {file_path}: {e}")
                 continue
-        
+
         return sorted(templates, key=lambda x: x['name'])
 
     def use_bank_template(self, template_name: str) -> Optional[QueuedPrompt]:
         """Copy a template from bank to queue and return as QueuedPrompt."""
         bank_file = self.bank_dir / f"{template_name}.md"
-        
+
         if not bank_file.exists():
             return None
-        
+
         try:
             # Parse the bank template
             template_prompt = self.parser.parse_prompt_file(bank_file)
             if not template_prompt:
                 return None
-            
+
             # Generate new ID for the queue
             import uuid
             new_id = str(uuid.uuid4())[:8]
@@ -410,9 +578,9 @@ What should be delivered...
             template_prompt.last_executed = None
             template_prompt.rate_limited_at = None
             template_prompt.reset_time = None
-            
+
             return template_prompt
-            
+
         except Exception as e:
             print(f"Error using bank template {template_name}: {e}")
             return None
@@ -420,10 +588,10 @@ What should be delivered...
     def delete_bank_template(self, template_name: str) -> bool:
         """Delete a template from the bank."""
         bank_file = self.bank_dir / f"{template_name}.md"
-        
+
         if not bank_file.exists():
             return False
-        
+
         try:
             bank_file.unlink()
             return True


### PR DESCRIPTION
## Summary

> **Depends on #13** — please merge that PR first. This branch is based on `fix/bug-fixes`; the combined diff against `main` includes both PRs' changes. Once #13 is merged, this PR's diff will show only the delta.

Adds defensive security measures, makes subprocess execution thread-safe, narrows rate-limit detection scope to stderr, and refactors the CLI to avoid depending on the `claude` binary for non-daemon subcommands.

### Execution reliability (E1)
- Replace `os.chdir()` with `cwd=` in `subprocess.run()` — `os.chdir()` changes the entire process CWD and is not thread-safe; `cwd=` is scoped to the child process
- Context file paths now resolve against `working_dir` rather than the process CWD

### Rate-limit detection (R3, S11a, S11b)
- Scan only `result.stderr` for rate-limit patterns — searching stdout caused false positives when Claude's own output contained rate-limit-related phrases
- Remove the `"limit exceeded"` pattern (too broad — matched Python tracebacks, `ulimit` errors, compiler output)
- Restrict scan to the first 2 048 characters of stderr — genuine rate-limit messages are short and appear at the top; the cap prevents false positives from large subprocess output
- Warn at startup if the installed `claude` binary predates 2.1.50 (the version that moved rate-limit messages to stderr)

### Security hardening (SC1–SC4)
- Resolve `claude` command to an absolute path via `shutil.which()` at startup — prevents PATH-hijacking between startup and each subprocess call (SC4)
- Cap parsed/estimated reset times to at most 24 h from now via `_cap_reset_time()` — guards against a buggy binary stalling the queue indefinitely (SC4)
- Warn when `working_directory` resolves outside the user's home directory (SC2)
- Add `skip_permissions: bool = True` to `QueueManager` and `ClaudeCodeInterface`; add `--no-skip-permissions` flag to `claude-queue start` so operators can opt out of `--dangerously-skip-permissions` (SC1)
- `chmod(0o600)` every queue file written by `write_prompt_file()` (SC3)

### CLI refactor (E3)
- `QueueManager` is constructed only in `cmd_start` and `cmd_test` — all other subcommands (`add`, `status`, `list`, `cancel`, `template`, `bank *`) now use `QueueStorage` directly, removing the spurious `claude` binary dependency for everyday queue operations
- `cmd_add` and `cmd_cancel` use `_save_single_prompt()` directly instead of loading/saving the entire state
- Better `✓`/`✗` output for `add`, `cancel`, and `bank use`

### Dev dependencies
- `pyproject.toml`: add `[project.optional-dependencies] dev` with `pytest>=7.0` and `pytest-mock>=3.0`

## Test plan

- [ ] `claude-queue add "test prompt"` works without `claude` in PATH (no binary dependency for non-daemon commands)
- [ ] `claude-queue start --no-skip-permissions` launches the daemon without `--dangerously-skip-permissions` being passed to `claude`
- [ ] Rate-limit detection does not fire on a prompt whose output contains the word "rate limit" in Claude's response text
- [ ] A `working_directory` outside `$HOME` prints a warning but still executes
- [ ] Queue directory and prompt files are created with `0o700`/`0o600` permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)