### PR TITLE
chore: ignore __pycache__ and .pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 src/claude_code_queue.egg-info/
 dev.md
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary

- Adds `__pycache__/` and `*.pyc` to `.gitignore` so Python bytecode cache directories are never accidentally tracked

## Test plan

- [ ] Confirm `git status` no longer shows `__pycache__` directories as untracked after running tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)