### PR TITLE
fix: Ctrl+C kills running claude subprocess instead of waiting

### DIFF
--- a/src/claude_code_queue/claude_interface.py
+++ b/src/claude_code_queue/claude_interface.py
@@ -95,7 +95,8 @@ class ClaudeCodeInterface:
                         f"Warning: claude {version_str!r} predates stderr-only rate-limit "
                         f"detection (threshold "
                         f"{'.'.join(str(x) for x in _STDERR_RATE_LIMIT_MIN_VERSION)}). "
-                        "Rate-limit messages written to stdout will be missed.",
+                        "On successful executions (returncode=0), rate-limit messages on "
+                        "stdout will be missed. Non-zero exits are covered by the stdout scan.",
                         file=sys.stderr,
                     )
 
@@ -174,9 +175,39 @@ class ClaudeCodeInterface:
             # Searching stdout causes false positives if Claude's response happens to
             # contain any trigger phrase (e.g., code that handles rate limits).
             # Caveat: if older versions of the `claude` CLI write rate-limit messages to
-            # stdout, this change will miss them (see _STDERR_RATE_LIMIT_MIN_VERSION).
+            # stdout on successful executions (returncode=0), this will miss them
+            # (see _STDERR_RATE_LIMIT_MIN_VERSION). For returncode != 0 exits, stdout
+            # is also scanned by the Fix 2 block below.
             rate_limit_info = self._detect_rate_limit(result.stderr)
             is_non_retryable = self._detect_non_retryable_error(result.stderr)
+
+            # Fix 2 — Mid-execution rate-limit: when the process exits non-zero and
+            # stderr has no rate-limit pattern, also scan stdout.
+            # Rationale: a usage-limit hit during an active conversation causes the CLI
+            # to emit the notice on stdout (conversation stream) then exit non-zero.
+            # Scanning stdout is safe here because returncode != 0 is incompatible with
+            # a genuine successful Claude response, so no false positive can occur.
+            #
+            # IMPORTANT: scan the TAIL, not the head.
+            # _detect_rate_limit() internally applies output[:_RATE_LIMIT_SCAN_CHARS].
+            # For a long-running conversation (e.g. 62s), stdout begins with thousands
+            # of characters of conversation output; the rate-limit notice appears at the
+            # very end of the stream. Passing the tail ensures the scan window covers
+            # the error, not the start of the conversation.
+            if result.returncode != 0 and not rate_limit_info.is_rate_limited and result.stdout:
+                # broad_patterns=False: only stdout-safe patterns are used here.
+                # Unlike stderr (where genuine Claude CLI messages appear at the very
+                # start and the scan-window guards depth), the stdout tail can contain
+                # subprocess output that legitimately includes broad phrases like
+                # "rate limited", "too many requests", "quota exceeded",
+                # "rate_limit_error" (in user code), or "rate limit exceeded".
+                # Allowing them would turn a subprocess failure into a
+                # false-positive ~5-hour rate-limit hold.
+                stdout_tail = result.stdout[-_RATE_LIMIT_SCAN_CHARS:]
+                stdout_rate_limit_info = self._detect_rate_limit(stdout_tail, broad_patterns=False)
+                if stdout_rate_limit_info.is_rate_limited:
+                    stdout_rate_limit_info.detection_source = "stdout"
+                    rate_limit_info = stdout_rate_limit_info
 
             success = result.returncode == 0 and not rate_limit_info.is_rate_limited
 
@@ -206,7 +237,11 @@ class ClaudeCodeInterface:
                 execution_time=execution_time,
             )
 
-    def _detect_rate_limit(self, output: str) -> RateLimitInfo:
+    def _detect_rate_limit(
+        self,
+        output: str,
+        broad_patterns: bool = True,  # True for stderr (common path); False for stdout scanning (Fix 2)
+    ) -> RateLimitInfo:
         """Detect rate limiting from Claude Code output."""
         # S11b: restrict pattern scan to the first _RATE_LIMIT_SCAN_CHARS characters.
         # Genuine rate-limit messages from the Claude CLI are short and always appear
@@ -216,16 +251,37 @@ class ClaudeCodeInterface:
         scan_window = output[:_RATE_LIMIT_SCAN_CHARS].lower()
 
         # S11a: 'limit exceeded' removed — too broad (matches Python tracebacks, shell
-        # ulimit errors, compiler output, etc.). Every meaningful Claude CLI rate-limit
-        # scenario is covered by the remaining four patterns.
-        # ASSUMPTION: the Claude CLI never uses bare "api limit exceeded" without a
-        # "rate", "quota", or "usage" qualifier. Re-verify if CLI output format changes.
+        # ulimit errors, compiler output, etc.). Re-verify if CLI output format changes.
+        # Fix 1: patterns split into stdout-safe and broad tiers. Stdout-safe patterns
+        # are specific to Anthropic messaging ("your" or pipe-delimited timestamp format);
+        # broad patterns are safe for stderr but risk false positives in stdout.
+        #
+        # Stdout-safe patterns — listed timestamp-extractor-first so that the richer
+        # _extract_reset_time_from_limit_message() fires before _estimate_reset_time()
+        # for any pattern that could theoretically match the same input.
         rate_limit_patterns = [
-            ("usage limit reached", self._extract_reset_time_from_limit_message),
-            ("rate limit exceeded", self._estimate_reset_time),
-            ("too many requests", self._estimate_reset_time),
-            ("quota exceeded", self._estimate_reset_time),
+            ("usage limit reached", self._extract_reset_time_from_limit_message),  # "usage limit reached|<ts>"
+            ("exceeded your rate limit", self._estimate_reset_time),  # "you have exceeded your rate limit"
+            ("reached your usage limit", self._estimate_reset_time),   # "you've/have reached your usage limit" (no apostrophe to avoid U+2019 mismatch)
         ]
+        # Broad patterns — safe for stderr (genuine Claude CLI messages appear at the
+        # very start; the scan-window provides depth protection) but NOT safe for
+        # stdout scanning, where subprocess output (npm, pip, curl, etc.) can
+        # legitimately contain these phrases, causing a false-positive ~5-hour hold.
+        #
+        # "rate limit exceeded" — HTTP 429 standard text; third-party APIs use it.
+        # "rate_limit_error" — Anthropic API type, but appears in user-generated code.
+        # "too many requests" — HTTP 429 status text; npm/pip/cloud CLIs print it.
+        # "quota exceeded" — GCP/AWS/Azure quota error messages use it.
+        # "rate limited" — common English phrase in network library output.
+        if broad_patterns:
+            rate_limit_patterns.extend([
+                ("rate limit exceeded", self._estimate_reset_time),
+                ("rate_limit_error", self._estimate_reset_time),       # Anthropic API machine-readable type
+                ("too many requests", self._estimate_reset_time),
+                ("quota exceeded", self._estimate_reset_time),
+                ("rate limited", self._estimate_reset_time),           # "you are rate limited"
+            ])
 
         for pattern, reset_extractor in rate_limit_patterns:
             if pattern in scan_window:

--- a/src/claude_code_queue/claude_interface.py
+++ b/src/claude_code_queue/claude_interface.py
@@ -2,11 +2,14 @@
 Interface for executing prompts via Claude Code CLI.
 """
 
+import atexit
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
+import threading
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -49,6 +52,32 @@ _NON_RETRYABLE_PATTERNS = [
     "claude code cannot be launched inside another claude code session",
 ]
 
+# signal.SIGKILL is not defined on Windows (only POSIX).  Referencing it
+# directly (e.g., signal.SIGKILL) raises AttributeError on Windows.  This
+# constant provides the numeric value (9) on all platforms so callers never
+# need a getattr guard at every call site.  _kill_proc_group() already
+# handles the Windows fallback (proc.kill() instead of os.killpg).
+_SIGKILL = getattr(signal, "SIGKILL", 9)
+
+# signal.SIGTERM exists on both POSIX and Windows, but define it as a
+# module constant for symmetry with _SIGKILL and to allow tests to import
+# it alongside _SIGKILL without referencing the signal module directly.
+_SIGTERM = getattr(signal, "SIGTERM", 15)
+
+# Seconds to wait for the subprocess to exit after SIGTERM before
+# escalating to SIGKILL.  3 seconds balances responsiveness (user expects
+# fast Ctrl+C) with giving well-behaved processes time to clean up.
+# Most processes exit within 100ms of SIGTERM; 3s is generous.
+# Used by the daemon thread in kill_current().
+_KILL_ESCALATION_TIMEOUT_S = 3
+
+# Seconds to wait for the subprocess leader to exit after SIGKILL in the
+# except-TimeoutExpired handler.  SIGKILL is immediate (the only exception
+# is a process stuck in uninterruptible sleep / D state), so 2 seconds is
+# generous.  Caps the proc.wait() call so an unusual delay cannot block
+# the queue indefinitely.
+_DRAIN_TIMEOUT_S = 2
+
 
 class ClaudeCodeInterface:
     """Interface for executing prompts via Claude Code CLI."""
@@ -58,6 +87,16 @@ class ClaudeCodeInterface:
         self.claude_command = claude_command
         self.timeout = timeout
         self.skip_permissions = skip_permissions
+        self._current_process: Optional[subprocess.Popen] = None
+        self._interrupted: bool = False
+        self._escalate_thread: Optional[threading.Thread] = None
+
+        # Defense-in-depth: if the Python process exits without going through
+        # _signal_handler() or the except-BaseException cleanup, kill any
+        # still-running subprocess rather than leaving it orphaned.
+        self._atexit_handler = self._atexit_cleanup
+        atexit.register(self._atexit_handler)
+
         self._verify_claude_available()
 
     def _verify_claude_available(self) -> None:
@@ -106,6 +145,116 @@ class ClaudeCodeInterface:
             )
         except subprocess.TimeoutExpired:
             raise RuntimeError("Claude Code CLI verification timed out.")
+
+    def _atexit_cleanup(self) -> None:
+        """Wrapper for atexit — survives interpreter shutdown.
+
+        During interpreter shutdown, module globals (``os``, ``signal``,
+        ``sys``) may already be set to ``None``.  This wrapper swallows
+        all exceptions so the shutdown sequence is never disrupted.
+        """
+        try:
+            self.kill_current()
+        except BaseException:
+            pass
+
+    def close(self) -> None:
+        """Unregister the atexit handler.
+
+        Call this when the ``ClaudeCodeInterface`` instance is no longer
+        needed (e.g., in test fixture teardown) to prevent atexit handlers
+        from accumulating across the process lifetime.  Safe to call
+        multiple times — ``atexit.unregister`` is a no-op if the callable
+        was never registered or was already unregistered.
+        """
+        atexit.unregister(self._atexit_handler)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    @staticmethod
+    def _kill_proc_group(proc: subprocess.Popen, sig: int) -> bool:
+        """Send *sig* to the subprocess's process group, or to the process
+        directly on Windows where ``os.killpg`` is absent.
+
+        INVARIANT: This method uses ``proc.pid`` as the PGID.  This is only
+        correct because ``execute_prompt()`` launches the subprocess with
+        ``start_new_session=True`` (POSIX), making the child a session leader
+        whose PID == PGID.
+
+        Returns ``True`` if the signal was sent successfully, ``False`` if the
+        process group was already gone (``OSError``).
+        """
+        try:
+            if hasattr(os, "killpg"):
+                os.killpg(proc.pid, sig)
+            else:
+                # Windows: no process-group kill; fall back to single-process.
+                if sig == _SIGKILL:
+                    proc.kill()
+                else:
+                    proc.terminate()
+            return True
+        except (OSError, AttributeError):
+            return False
+
+    def kill_current(self) -> None:
+        """Terminate the currently-running claude subprocess, if any.
+
+        Safe to call from a signal handler — returns immediately after
+        sending SIGTERM.  A daemon thread escalates to SIGKILL after
+        ``_KILL_ESCALATION_TIMEOUT_S`` seconds if the child has not exited.
+
+        NOTE: Uses ``os.write(2, ...)`` instead of ``print()`` to avoid
+        re-entering the stream lock if the main thread is mid-print.
+        """
+        proc = self._current_process
+
+        if proc is None:
+            return
+
+        # Signal-safe stderr write
+        try:
+            os.write(2, f"Terminating subprocess (pid={proc.pid})...\n".encode())
+        except OSError:
+            pass
+
+        if not self._kill_proc_group(proc, _SIGTERM):
+            return                    # process group already gone
+
+        self._interrupted = True
+
+        # Escalate to SIGKILL in a daemon thread so the signal handler
+        # returns immediately.
+        #
+        # Capture references as locals: during interpreter shutdown, module
+        # globals may already be None.
+        _kill = ClaudeCodeInterface._kill_proc_group
+        _sigkill = _SIGKILL
+        _escalation_timeout = _KILL_ESCALATION_TIMEOUT_S
+
+        def _escalate(p: subprocess.Popen) -> None:
+            try:
+                try:
+                    p.wait(timeout=_escalation_timeout)
+                    return
+                except subprocess.TimeoutExpired:
+                    try:
+                        os.write(2, f"Subprocess (pid={p.pid}) ignored SIGTERM for "
+                                 f"{_escalation_timeout}s; escalating to SIGKILL\n".encode())
+                    except (OSError, AttributeError):
+                        pass
+                    _kill(p, _sigkill)
+            except BaseException:
+                pass
+
+        self._escalate_thread = threading.Thread(
+            target=_escalate, args=(proc,), daemon=True
+        )
+        self._escalate_thread.start()
 
     def execute_prompt(self, prompt: QueuedPrompt) -> ExecutionResult:
         """Execute a prompt via Claude Code CLI."""
@@ -164,9 +313,60 @@ class ClaudeCodeInterface:
             # anti-nesting guard. The rest of the environment (PATH, HOME, API keys, etc.)
             # is preserved unchanged.
             subprocess_env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=self.timeout,
-                cwd=str(working_dir), env=subprocess_env
+
+            # Captures the interrupt flag across all exit paths — see finally block.
+            _was_interrupted = False
+
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,    # isolate from terminal SIGINT; also required by _kill_proc_group()
+                cwd=str(working_dir),
+                env=subprocess_env,
+            )
+            self._interrupted = False             # clear stale flag before registering proc
+            self._current_process = proc
+
+            try:
+                stdout, stderr = proc.communicate(timeout=self.timeout)
+            except subprocess.TimeoutExpired:
+                ClaudeCodeInterface._kill_proc_group(proc, _SIGKILL)
+                try:
+                    proc.wait(timeout=_DRAIN_TIMEOUT_S)
+                except subprocess.TimeoutExpired:
+                    pass
+                for _pipe in (proc.stdout, proc.stderr):
+                    if _pipe:
+                        try:
+                            _pipe.close()
+                        except OSError:
+                            pass
+                raise
+            except BaseException:
+                ClaudeCodeInterface._kill_proc_group(proc, _SIGKILL)
+                for _pipe in (proc.stdout, proc.stderr):
+                    if _pipe:
+                        try:
+                            _pipe.close()
+                        except OSError:
+                            pass
+                raise
+            finally:
+                self._current_process = None
+                _was_interrupted = self._interrupted
+                self._interrupted = False
+
+            if _was_interrupted:
+                raise KeyboardInterrupt
+
+            result = subprocess.CompletedProcess(
+                cmd,
+                proc.returncode,
+                stdout=stdout,
+                stderr=stderr,
             )
 
             execution_time = time.time() - start_time
@@ -229,6 +429,10 @@ class ClaudeCodeInterface:
                 execution_time=execution_time,
             )
         except Exception as e:
+            # If a signal-driven kill was requested but communicate() raised
+            # an exception instead of returning normally, treat as interrupt.
+            if _was_interrupted:
+                raise KeyboardInterrupt
             execution_time = time.time() - start_time
             return ExecutionResult(
                 success=False,
@@ -448,6 +652,13 @@ class ClaudeCodeInterface:
     def execute_simple_prompt(
         self, prompt_text: str, working_dir: str = "."
     ) -> ExecutionResult:
-        """Execute a simple prompt without full QueuedPrompt object."""
+        """Execute a simple prompt without full QueuedPrompt object.
+
+        Note: Ctrl+C kills the subprocess via the ``except BaseException``
+        cleanup, but does not revert the prompt to QUEUED (no ``_shutdown()``
+        exists in standalone usage).  For full Ctrl+C support with automatic
+        revert, use ``QueueManager`` which installs signal handlers that call
+        ``kill_current()``.
+        """
         simple_prompt = QueuedPrompt(content=prompt_text, working_directory=working_dir)
         return self.execute_prompt(simple_prompt)

--- a/src/claude_code_queue/claude_interface.py
+++ b/src/claude_code_queue/claude_interface.py
@@ -2,6 +2,7 @@
 Interface for executing prompts via Claude Code CLI.
 """
 
+import os
 import re
 import shutil
 import subprocess
@@ -29,6 +30,25 @@ _RATE_LIMIT_MAX_RESET_HOURS = 24
 # CLI output this equals the byte count.
 _RATE_LIMIT_SCAN_CHARS = 2048
 
+# Only scan this many characters of stderr for non-retryable patterns.
+# The nested-session message is short (≤ ~200 chars) and appears near the top
+# of stderr. The cap mirrors the _RATE_LIMIT_SCAN_CHARS guard: it prevents a
+# subprocess tool whose verbose debug output happens to contain a matching phrase
+# from triggering a false positive. Set larger than _RATE_LIMIT_SCAN_CHARS (2 048)
+# because future non-retryable patterns may appear after longer preambles.
+_NON_RETRYABLE_SCAN_CHARS = 8192
+
+# Errors that are structurally permanent — retrying will never produce a different
+# outcome. When any of these substrings is found in the first _NON_RETRYABLE_SCAN_CHARS
+# characters of stderr (case-insensitive), the ExecutionResult is marked
+# is_non_retryable=True and _process_execution_result() will skip the retry logic
+# and immediately mark the prompt FAILED.
+#
+# Keep patterns specific enough to avoid false positives.
+_NON_RETRYABLE_PATTERNS = [
+    "claude code cannot be launched inside another claude code session",
+]
+
 
 class ClaudeCodeInterface:
     """Interface for executing prompts via Claude Code CLI."""
@@ -52,11 +72,13 @@ class ClaudeCodeInterface:
                 if resolved:
                     self.claude_command = resolved
 
+            subprocess_env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
             result = subprocess.run(
                 [self.claude_command, "--version"],
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=subprocess_env,
             )
             if result.returncode != 0:
                 raise RuntimeError(f"Claude Code CLI not available: {result.stderr}")
@@ -137,9 +159,13 @@ class ClaudeCodeInterface:
             # E1 — Use cwd= instead of os.chdir() to set the subprocess working directory.
             # This is thread-safe: os.chdir() changes the entire process CWD, which breaks
             # concurrent executions and any other thread that relies on getcwd().
+            # Fix A — Strip CLAUDECODE so nested claude invocations are not blocked by the
+            # anti-nesting guard. The rest of the environment (PATH, HOME, API keys, etc.)
+            # is preserved unchanged.
+            subprocess_env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
             result = subprocess.run(
                 cmd, capture_output=True, text=True, timeout=self.timeout,
-                cwd=str(working_dir)
+                cwd=str(working_dir), env=subprocess_env
             )
 
             execution_time = time.time() - start_time
@@ -150,6 +176,7 @@ class ClaudeCodeInterface:
             # Caveat: if older versions of the `claude` CLI write rate-limit messages to
             # stdout, this change will miss them (see _STDERR_RATE_LIMIT_MIN_VERSION).
             rate_limit_info = self._detect_rate_limit(result.stderr)
+            is_non_retryable = self._detect_non_retryable_error(result.stderr)
 
             success = result.returncode == 0 and not rate_limit_info.is_rate_limited
 
@@ -159,6 +186,7 @@ class ClaudeCodeInterface:
                 error=result.stderr,
                 rate_limit_info=rate_limit_info,
                 execution_time=execution_time,
+                is_non_retryable=is_non_retryable,
             )
 
         except subprocess.TimeoutExpired:
@@ -210,6 +238,20 @@ class ClaudeCodeInterface:
                 )
 
         return RateLimitInfo(is_rate_limited=False)
+
+    def _detect_non_retryable_error(self, stderr: str) -> bool:
+        """Return True if stderr contains a non-retryable error pattern.
+
+        Only the first _NON_RETRYABLE_SCAN_CHARS characters of stderr are scanned.
+        The nested-session message appears within the first ~200 chars, so the cap
+        never misses it; the cap does prevent long tool output from triggering false
+        positives if a future pattern is less specific.
+
+        Matching is case-insensitive: each pattern is lowercased at match time, so
+        entries in _NON_RETRYABLE_PATTERNS may be any case.
+        """
+        scan_window = stderr[:_NON_RETRYABLE_SCAN_CHARS].lower()
+        return any(pattern.lower() in scan_window for pattern in _NON_RETRYABLE_PATTERNS)
 
     def _extract_reset_time_from_limit_message(self, output: str) -> Optional[datetime]:
         """Extract reset time from Claude's limit message."""
@@ -291,11 +333,13 @@ class ClaudeCodeInterface:
     def test_connection(self) -> Tuple[bool, str]:
         """Test if Claude Code is working."""
         try:
+            subprocess_env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
             result = subprocess.run(
                 [self.claude_command, "--help"],
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=subprocess_env,
             )
 
             if result.returncode == 0:
@@ -313,11 +357,13 @@ class ClaudeCodeInterface:
     def get_available_commands(self) -> List[str]:
         """Get available Claude Code commands."""
         try:
+            subprocess_env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
             result = subprocess.run(
                 [self.claude_command, "--help"],
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=subprocess_env,
             )
 
             if result.returncode == 0:

--- a/src/claude_code_queue/models.py
+++ b/src/claude_code_queue/models.py
@@ -208,6 +208,7 @@ class ExecutionResult:
     error: str = ""
     rate_limit_info: Optional[RateLimitInfo] = None
     execution_time: float = 0.0
+    is_non_retryable: bool = False  # True if the error is permanent regardless of retry count
 
     @property
     def is_rate_limited(self) -> bool:

--- a/src/claude_code_queue/models.py
+++ b/src/claude_code_queue/models.py
@@ -38,6 +38,7 @@ class QueuedPrompt:
     last_executed: Optional[datetime] = None
     rate_limited_at: Optional[datetime] = None
     reset_time: Optional[datetime] = None
+    retry_not_before: Optional[datetime] = None  # Fix 3: earliest time for next generic retry
 
     def add_log(self, message: str) -> None:
         """Add a log entry with timestamp."""
@@ -57,15 +58,36 @@ class QueuedPrompt:
         has_retries = self.max_retries == -1 or self.retry_count < self.max_retries
         return has_retries
 
-    def should_execute_now(self) -> bool:
-        """Check if this prompt should be executed now (not rate limited)."""
-        if self.status != PromptStatus.RATE_LIMITED:
-            return True
+    def clear_retry_backoff(self) -> None:
+        """Clear the generic-failure retry backoff.
 
-        if self.reset_time and datetime.now() >= self.reset_time:
-            return True
+        INVARIANT: must be called on every status transition except the
+        generic-failure retry path in _process_execution_result(), which is the
+        only place that SETS retry_not_before. Centralising the clear in a named
+        method makes grep easy and documents the single exception.
+        """
+        self.retry_not_before = None
 
-        return False
+    def should_execute_now(self, now: Optional[datetime] = None) -> bool:
+        """Check if this prompt should be executed now (not rate limited or in cooldown).
+
+        Called by get_next_prompt() for QUEUED and RATE_LIMITED prompts only.
+
+        Args:
+            now: current time, passed by get_next_prompt() so all prompts in a
+                 single selection pass are evaluated against the same timestamp.
+                 Falls back to datetime.now() for standalone calls.
+        """
+        if now is None:
+            now = datetime.now()
+        if self.status == PromptStatus.RATE_LIMITED:
+            if self.reset_time and now >= self.reset_time:
+                return True
+            return False
+        # Fix 3: honour per-prompt generic-failure cooldown for QUEUED prompts.
+        if self.retry_not_before is not None and now < self.retry_not_before:
+            return False
+        return True
 
 
 @dataclass
@@ -76,10 +98,19 @@ class RateLimitInfo:
     reset_time: Optional[datetime] = None
     limit_message: str = ""
     timestamp: Optional[datetime] = None
+    detection_source: str = "stderr"  # "stderr" (default) or "stdout"; set by execute_prompt()
 
     @classmethod
     def from_claude_response(cls, response_text: str) -> "RateLimitInfo":
-        """Parse rate limit info from Claude Code response."""
+        """Parse rate limit info from Claude Code response.
+
+        LEGACY / TEST-ONLY PATH — this method is not called by the production
+        execution path (ClaudeCodeInterface._detect_rate_limit() handles that).
+        Its pattern list intentionally diverges from _detect_rate_limit(): it
+        still includes the broad "limit exceeded" phrase (removed from production
+        code in S11a) and does not include the Fix 1 additions. Do not use this
+        method for new production code; update _detect_rate_limit() instead.
+        """
         # Common rate limit indicators in Claude Code responses
         rate_limit_indicators = [
             "usage limit reached",
@@ -116,10 +147,11 @@ class QueueState:
 
     def get_next_prompt(self) -> Optional[QueuedPrompt]:
         """Get the next prompt to execute (highest priority, can execute now)."""
+        now = datetime.now()
         executable_prompts = [
             p
             for p in self.prompts
-            if p.status == PromptStatus.QUEUED and p.should_execute_now()
+            if p.status == PromptStatus.QUEUED and p.should_execute_now(now)
         ]
 
         if not executable_prompts:
@@ -128,13 +160,16 @@ class QueueState:
                 p
                 for p in self.prompts
                 if p.status == PromptStatus.RATE_LIMITED
-                and p.should_execute_now()
+                and p.should_execute_now(now)
                 and p.can_retry()
             ]
             if retry_prompts:
                 # Reset status for retry
                 prompt = min(retry_prompts, key=lambda p: p.priority)
                 prompt.status = PromptStatus.QUEUED
+                prompt.clear_retry_backoff()    # Fix 3: mirror _check_rate_limited_prompts(); clear so
+                                                 # should_execute_now() returns True immediately after
+                                                 # the RATE_LIMITED→QUEUED transition.
                 return prompt
 
             return None

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -2,6 +2,7 @@
 Queue manager with execution loop.
 """
 
+import os
 import sys
 import time
 import signal
@@ -44,7 +45,13 @@ class QueueManager:
 
     def _signal_handler(self, signum, frame):
         """Handle shutdown signals."""
-        print(f"\nReceived signal {signum}, shutting down gracefully...")
+        # Signal-safe stderr write — avoids re-entering print()'s stream lock
+        # if the main thread is mid-print when the signal fires.
+        try:
+            os.write(2, f"\nReceived signal {signum}, shutting down gracefully...\n".encode())
+        except OSError:
+            pass
+        self.claude_interface.kill_current()  # unblocks communicate() if executing
         self.stop()
 
     def start(self, callback: Optional[Callable[[QueueState], None]] = None) -> None:
@@ -88,6 +95,8 @@ class QueueManager:
                     time.sleep(self.check_interval)
 
         except KeyboardInterrupt:
+            # print() is safe: we are in normal execution context, not signal-handler
+            # context.  The signal handler used os.write(2, ...) and has already returned.
             print("\nShutdown requested by user")
         except Exception as e:
             print(f"Error in queue processing: {e}")
@@ -100,6 +109,9 @@ class QueueManager:
 
     def _shutdown(self) -> None:
         """Clean shutdown procedure."""
+        # print() is safe here: _shutdown() runs from the finally block in start(),
+        # which is normal execution context (not signal-handler context).  The signal
+        # handler itself uses os.write(2, ...) to avoid stream-lock re-entrance.
         print("Shutting down...")
 
         if self.state:
@@ -233,6 +245,9 @@ class QueueManager:
 
         self.storage.save_queue_state(self.state)
 
+        # execute_prompt() may raise KeyboardInterrupt (Ctrl+C path).
+        # _process_execution_result() is intentionally bypassed in that case;
+        # the prompt stays EXECUTING for _shutdown() to revert to QUEUED.
         result = self.claude_interface.execute_prompt(prompt)
 
         self._process_execution_result(prompt, result)

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -2,6 +2,7 @@
 Queue manager with execution loop.
 """
 
+import sys
 import time
 import signal
 from datetime import datetime, timedelta
@@ -22,6 +23,7 @@ class QueueManager:
         check_interval: int = 30,
         timeout: int = 3600,
         skip_permissions: bool = True,
+        generic_failure_retry_delay: int = 60,
     ):
         self.storage = QueueStorage(storage_dir)
         self.claude_interface = ClaudeCodeInterface(claude_command, timeout,
@@ -29,6 +31,13 @@ class QueueManager:
         self.check_interval = check_interval
         self.running = False
         self.state: Optional[QueueState] = None
+        if generic_failure_retry_delay < 1:
+            print(
+                f"Warning: generic_failure_retry_delay={generic_failure_retry_delay} "
+                f"clamped to 1 to prevent retry spin loops",
+                file=sys.stderr,
+            )
+        self._generic_failure_retry_delay = max(1, generic_failure_retry_delay)
 
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
@@ -51,6 +60,23 @@ class QueueManager:
 
         self.state = self.storage.load_queue_state()
         print(f"✓ Loaded queue with {len(self.state.prompts)} prompts")
+
+        # Fix 3: warn about cooldown-blocked prompts so operators aren't confused
+        # when the queue appears stuck for up to 60 seconds after restart.
+        now = datetime.now()
+        cooldown_count = sum(
+            1 for p in self.state.prompts
+            if p.status == PromptStatus.QUEUED
+            and p.retry_not_before is not None
+            and now < p.retry_not_before
+        )
+        if cooldown_count:
+            soonest = min(
+                p.retry_not_before for p in self.state.prompts
+                if p.retry_not_before is not None and now < p.retry_not_before
+            )
+            wait = max(1, int((soonest - now).total_seconds()))
+            print(f"⏳ {cooldown_count} prompt(s) in retry cooldown (next eligible in {wait}s)")
 
         self.running = True
 
@@ -79,6 +105,17 @@ class QueueManager:
         if self.state:
             for prompt in self.state.prompts:
                 if prompt.status == PromptStatus.EXECUTING:
+                    # Invariant: _execute_prompt() must clear retry_not_before
+                    # in-memory before save_queue_state() writes .executing.md, so by the
+                    # time _shutdown() runs, retry_not_before is already None.
+                    if prompt.retry_not_before is not None:
+                        print(
+                            f"Warning: prompt {prompt.id} has stale "
+                            f"retry_not_before={prompt.retry_not_before} during shutdown "
+                            f"(expected None); clearing. Check call order in _execute_prompt().",
+                            file=sys.stderr,
+                        )
+                        prompt.clear_retry_backoff()
                     prompt.status = PromptStatus.QUEUED
                     prompt.add_log("Execution interrupted during shutdown")
 
@@ -117,7 +154,22 @@ class QueueManager:
                     f"Waiting for rate limit reset ({len(rate_limited_prompts)} prompts rate limited)"
                 )
             else:
-                print("No prompts in queue")
+                now = datetime.now()
+                cooldown_prompts = [
+                    p for p in self.state.prompts
+                    if p.status == PromptStatus.QUEUED
+                    and p.retry_not_before is not None
+                    and now < p.retry_not_before
+                ]
+                if cooldown_prompts:
+                    soonest = min(p.retry_not_before for p in cooldown_prompts)
+                    wait = max(0, (soonest - now).total_seconds())
+                    print(
+                        f"Waiting for retry cooldown ({len(cooldown_prompts)} prompt(s) in backoff, "
+                        f"next eligible in {max(1, int(wait))}s)"
+                    )
+                else:
+                    print("No prompts in queue")
 
             # Fix S8: _check_rate_limited_prompts() may have transitioned prompts to
             # FAILED. Save state so those transitions are persisted even when no prompt
@@ -159,16 +211,20 @@ class QueueManager:
 
             if prompt.can_retry():
                 prompt.status = PromptStatus.QUEUED
+                prompt.clear_retry_backoff()    # Fix 3: clear so the re-queued prompt is immediately
+                                                # selectable by get_next_prompt().
                 prompt.add_log("Retrying after rate limit cooldown")
                 print(f"✓ Prompt {prompt.id} ready for retry after cooldown")
             else:
                 prompt.status = PromptStatus.FAILED
+                prompt.clear_retry_backoff()    # Fix 3: clear stale field for YAML cleanliness
                 prompt.add_log(f"Max retries ({prompt.max_retries}) exceeded")
                 print(f"✗ Prompt {prompt.id} failed - max retries exceeded")
 
     def _execute_prompt(self, prompt: QueuedPrompt) -> None:
         """Execute a single prompt."""
         prompt.status = PromptStatus.EXECUTING
+        prompt.clear_retry_backoff()    # consumed; clear so it doesn't persist into .executing.md
         prompt.last_executed = datetime.now()
         retries_str = "∞" if prompt.max_retries == -1 else str(prompt.max_retries)
         prompt.add_log(
@@ -188,6 +244,7 @@ class QueueManager:
         execution_summary = f"Execution completed in {result.execution_time:.1f}s"
 
         if result.success:
+            # retry_not_before is already None — cleared by _execute_prompt() via clear_retry_backoff().
             prompt.status = PromptStatus.COMPLETED
             prompt.add_log(f"{execution_summary} - SUCCESS")
             if result.output:
@@ -202,6 +259,7 @@ class QueueManager:
             # takes precedence; a check nested inside else: would be silently bypassed if both
             # flags were ever set simultaneously.
             prompt.status = PromptStatus.FAILED
+            prompt.clear_retry_backoff()    # Fix 3: clear stale field for YAML cleanliness
             prompt.add_log(f"{execution_summary} - FAILED (non-retryable error, retry budget preserved)")
             if result.error:
                 prompt.add_log(f"Error: {result.error}")
@@ -230,7 +288,12 @@ class QueueManager:
 
             prompt.add_log(f"{execution_summary} - RATE LIMITED")
             if result.rate_limit_info and result.rate_limit_info.limit_message:
-                prompt.add_log(f"Message: {result.rate_limit_info.limit_message}")
+                source_tag = (
+                    " [via stdout]"
+                    if result.rate_limit_info.detection_source == "stdout"
+                    else ""
+                )
+                prompt.add_log(f"Message{source_tag}: {result.rate_limit_info.limit_message}")
 
             if not was_already_rate_limited and self.state is not None:
                 self.state.rate_limited_count += 1
@@ -241,15 +304,25 @@ class QueueManager:
 
             if prompt.can_retry():
                 prompt.status = PromptStatus.QUEUED
-                prompt.add_log(f"{execution_summary} - FAILED (will retry)")
+                # Fix 3 — Set retry_not_before so get_next_prompt() skips this prompt
+                # for self._generic_failure_retry_delay seconds, preventing a spin loop.
+                prompt.retry_not_before = datetime.now() + timedelta(
+                    seconds=self._generic_failure_retry_delay
+                )
+                prompt.add_log(
+                    f"{execution_summary} - FAILED "
+                    f"(will retry in {self._generic_failure_retry_delay}s)"
+                )
                 if result.error:
                     prompt.add_log(f"Error: {result.error}")
                 print(
-                    f"✗ Prompt {prompt.id} failed, will retry "
+                    f"✗ Prompt {prompt.id} failed, will retry in "
+                    f"{self._generic_failure_retry_delay}s "
                     f"({prompt.retry_count}/{'∞' if prompt.max_retries == -1 else prompt.max_retries})"
                 )
             else:
                 prompt.status = PromptStatus.FAILED
+                prompt.clear_retry_backoff()    # Fix 3: clear stale field for YAML cleanliness
                 prompt.add_log(f"{execution_summary} - FAILED (max retries exceeded)")
                 if result.error:
                     prompt.add_log(f"Error: {result.error}")

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -56,9 +56,9 @@ class QueueManager:
 
         try:
             while self.running:
-                self._process_queue_iteration(callback)
+                did_work = self._process_queue_iteration(callback)
 
-                if self.running:
+                if self.running and not did_work:
                     time.sleep(self.check_interval)
 
         except KeyboardInterrupt:
@@ -89,8 +89,8 @@ class QueueManager:
 
     def _process_queue_iteration(
         self, callback: Optional[Callable[[QueueState], None]] = None
-    ) -> None:
-        """Process one iteration of the queue."""
+    ) -> bool:
+        """Process one iteration of the queue. Returns True if a prompt was executed."""
         previous_total_processed = self.state.total_processed if self.state else 0
         previous_failed_count = self.state.failed_count if self.state else 0
         previous_rate_limited_count = self.state.rate_limited_count if self.state else 0
@@ -126,7 +126,7 @@ class QueueManager:
 
             if callback:
                 callback(self.state)
-            return
+            return False
 
         print(f"Executing prompt {next_prompt.id}: {next_prompt.content[:50]}...")
         self._execute_prompt(next_prompt)
@@ -135,6 +135,7 @@ class QueueManager:
 
         if callback:
             callback(self.state)
+        return True
 
     def _check_rate_limited_prompts(self) -> None:
         """Check if any rate-limited prompts should be retried."""

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -195,6 +195,20 @@ class QueueManager:
             self.state.total_processed += 1
             print(f"✓ Prompt {prompt.id} completed successfully")
 
+        elif result.is_non_retryable:
+            # Fix B — Non-retryable error: fail immediately, skip retry counter and can_retry().
+            # Placing is_non_retryable before is_rate_limited in the chain ensures it always
+            # takes precedence; a check nested inside else: would be silently bypassed if both
+            # flags were ever set simultaneously.
+            prompt.status = PromptStatus.FAILED
+            prompt.add_log(f"{execution_summary} - FAILED (non-retryable error, retry budget preserved)")
+            if result.error:
+                prompt.add_log(f"Error: {result.error}")
+            self.state.failed_count += 1
+            print(
+                f"✗ Prompt {prompt.id} failed permanently (non-retryable error, no retry)"
+            )
+
         elif result.is_rate_limited:
             # Fix S4: prompt.status is EXECUTING at this point — checking it against
             # RATE_LIMITED always returns False. Use rate_limited_at (persisted from
@@ -230,7 +244,8 @@ class QueueManager:
                 if result.error:
                     prompt.add_log(f"Error: {result.error}")
                 print(
-                    f"✗ Prompt {prompt.id} failed, will retry ({prompt.retry_count}/{prompt.max_retries})"
+                    f"✗ Prompt {prompt.id} failed, will retry "
+                    f"({prompt.retry_count}/{'∞' if prompt.max_retries == -1 else prompt.max_retries})"
                 )
             else:
                 prompt.status = PromptStatus.FAILED
@@ -239,8 +254,9 @@ class QueueManager:
                     prompt.add_log(f"Error: {result.error}")
 
                 self.state.failed_count += 1
+                retries_str = "∞" if prompt.max_retries == -1 else str(prompt.max_retries)
                 print(
-                    f"✗ Prompt {prompt.id} failed permanently after {prompt.max_retries} attempts"
+                    f"✗ Prompt {prompt.id} failed permanently after {retries_str} attempts"
                 )
 
         self.state.last_processed = datetime.now()

--- a/src/claude_code_queue/storage.py
+++ b/src/claude_code_queue/storage.py
@@ -401,7 +401,7 @@ class QueueStorage:
     @staticmethod
     def _sanitize_filename_static(text: str) -> str:
         """Sanitize text for use in filename (static version for use in parser)."""
-        invalid_chars = '<>:"/\\|?*#'
+        invalid_chars = '<>:"/\\|?*#\'`'
         for char in invalid_chars:
             text = text.replace(char, "-")
 

--- a/src/claude_code_queue/storage.py
+++ b/src/claude_code_queue/storage.py
@@ -323,7 +323,6 @@ class QueueStorage:
             if (
                 file_path.name.endswith(".executing.md")
                 or file_path.name.endswith(".rate-limited.md")
-                or "#" in file_path.name
             ):
                 continue
 
@@ -402,7 +401,7 @@ class QueueStorage:
     @staticmethod
     def _sanitize_filename_static(text: str) -> str:
         """Sanitize text for use in filename (static version for use in parser)."""
-        invalid_chars = '<>:"/\\|?*'
+        invalid_chars = '<>:"/\\|?*#'
         for char in invalid_chars:
             text = text.replace(char, "-")
 

--- a/src/claude_code_queue/storage.py
+++ b/src/claude_code_queue/storage.py
@@ -6,7 +6,7 @@ import json
 import re
 import shutil
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import List, Optional
 import yaml  # type: ignore
@@ -133,6 +133,9 @@ class MarkdownPromptParser:
                 reset_time=QueueStorage._parse_optional_datetime(
                     metadata.get("reset_time")
                 ),
+                retry_not_before=QueueStorage._parse_optional_datetime(
+                    metadata.get("retry_not_before")
+                ),
             )
 
             return prompt
@@ -164,6 +167,8 @@ class MarkdownPromptParser:
                 metadata["rate_limited_at"] = prompt.rate_limited_at.isoformat()
             if prompt.reset_time:
                 metadata["reset_time"] = prompt.reset_time.isoformat()
+            if prompt.retry_not_before is not None:
+                metadata["retry_not_before"] = prompt.retry_not_before.isoformat()
 
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write("---\n")
@@ -239,6 +244,18 @@ class QueueStorage:
         """
         if not val:
             return None
+        # Fast-path: PyYAML may return a native datetime object rather than a string
+        # when the YAML value matches the timestamp pattern (e.g. an unquoted isoformat).
+        # fromisoformat() requires a str; without this guard, the TypeError is silently
+        # swallowed by the except clause and the field is lost.
+        #
+        # ORDERING: datetime must be checked BEFORE date because datetime is a subclass
+        # of date — isinstance(datetime_obj, date) is True. Using elif makes this
+        # dependency explicit and prevents silent breakage if the checks are reordered.
+        if isinstance(val, datetime):
+            return val.replace(tzinfo=None)
+        elif isinstance(val, date):
+            return datetime.combine(val, datetime.min.time())
         try:
             if isinstance(val, str) and val.endswith("Z"):
                 val = val[:-1] + "+00:00"
@@ -308,6 +325,10 @@ class QueueStorage:
                 # Re-queue the prompt so it runs again on restart rather than
                 # leaving it permanently stuck in EXECUTING state.
                 prompt.status = PromptStatus.QUEUED
+                prompt.clear_retry_backoff()      # Fix 3: _execute_prompt() clears this before
+                                                 # writing .executing.md in normal operation, so
+                                                 # this guard should never fire. Included for
+                                                 # defensive completeness.
                 prompt.add_log("Recovered from interrupted execution (process restart)")
                 prompts.append(prompt)
                 processed_ids.add(prompt.id)
@@ -418,6 +439,9 @@ class QueueStorage:
                 shutil.move(str(file_path), str(new_path))
 
             prompt.status = PromptStatus.QUEUED
+            prompt.clear_retry_backoff()     # Fix 3: clear so an imported file that happens to
+                                             # carry retry_not_before in its frontmatter doesn't
+                                             # silently block execution.
             return prompt
         return None
 
@@ -577,6 +601,7 @@ What should be delivered...
             template_prompt.last_executed = None
             template_prompt.rate_limited_at = None
             template_prompt.reset_time = None
+            template_prompt.clear_retry_backoff()
 
             return template_prompt
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+"""
+Shared fixtures for claude-code-queue test suite.
+"""
+
+import pytest
+from claude_code_queue.models import QueuedPrompt, QueueState, PromptStatus
+from claude_code_queue.storage import QueueStorage
+from claude_code_queue.claude_interface import ClaudeCodeInterface
+from claude_code_queue.queue_manager import QueueManager
+
+
+@pytest.fixture
+def storage(tmp_path):
+    """QueueStorage backed by a fresh temporary directory."""
+    return QueueStorage(str(tmp_path))
+
+
+@pytest.fixture
+def interface(mocker):
+    """ClaudeCodeInterface with _verify_claude_available patched out."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    return ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+
+@pytest.fixture
+def manager(tmp_path, mocker):
+    """QueueManager backed by a fresh temporary directory, with Claude patched."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    mocker.patch.object(
+        ClaudeCodeInterface, "test_connection", return_value=(True, "ok")
+    )
+    return QueueManager(storage_dir=str(tmp_path), claude_command="claude")
+
+
+@pytest.fixture
+def sample_prompt():
+    """A QueuedPrompt with a known id and content for use in tests."""
+    return QueuedPrompt(id="abc12345", content="test prompt content")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,9 @@ def storage(tmp_path):
 def interface(mocker):
     """ClaudeCodeInterface with _verify_claude_available patched out."""
     mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    return ClaudeCodeInterface(claude_command="claude", timeout=60)
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+    yield iface
+    iface.close()
 
 
 @pytest.fixture
@@ -29,7 +31,9 @@ def manager(tmp_path, mocker):
     mocker.patch.object(
         ClaudeCodeInterface, "test_connection", return_value=(True, "ok")
     )
-    return QueueManager(storage_dir=str(tmp_path), claude_command="claude")
+    mgr = QueueManager(storage_dir=str(tmp_path), claude_command="claude")
+    yield mgr
+    mgr.claude_interface.close()
 
 
 @pytest.fixture

--- a/tests/test_claude_interface.py
+++ b/tests/test_claude_interface.py
@@ -1,0 +1,656 @@
+"""
+Tests for claude_interface.py — ClaudeCodeInterface (subprocess mocked).
+
+All tests use the `interface` fixture which patches _verify_claude_available
+so the constructor never actually calls the claude binary.
+"""
+
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_code_queue.claude_interface import (
+    ClaudeCodeInterface,
+    _RATE_LIMIT_MAX_RESET_HOURS,
+    _RATE_LIMIT_SCAN_CHARS,
+)
+from claude_code_queue.models import QueuedPrompt, RateLimitInfo, PromptStatus
+
+
+# ===========================================================================
+# Rate-Limit Detection
+# ===========================================================================
+
+
+def test_rate_limit_detected_usage_limit_reached(interface):  # CLI-001
+    """'usage limit reached' pattern triggers is_rate_limited=True."""
+    result = interface._detect_rate_limit("usage limit reached|1735689600")
+    assert result.is_rate_limited is True
+
+
+def test_rate_limit_detected_rate_limit_exceeded(interface):  # CLI-002
+    """'rate limit exceeded' pattern triggers is_rate_limited=True."""
+    result = interface._detect_rate_limit(
+        "Error: rate limit exceeded, please try again"
+    )
+    assert result.is_rate_limited is True
+
+
+def test_rate_limit_detected_too_many_requests(interface):  # CLI-003
+    """'429 too many requests' pattern triggers is_rate_limited=True."""
+    result = interface._detect_rate_limit("429 Too Many Requests")
+    assert result.is_rate_limited is True
+
+
+def test_rate_limit_not_detected_normal_output(interface):  # CLI-004
+    """Normal Claude output does not trigger rate-limit detection."""
+    result = interface._detect_rate_limit(
+        "Successfully refactored the authentication module."
+    )
+    assert result.is_rate_limited is False
+
+
+def test_rate_limit_detection_is_case_insensitive(interface):  # CLI-005
+    """Detection uses output.lower() — mixed-case strings are caught."""
+    result = interface._detect_rate_limit("Usage Limit Reached — please wait")
+    assert result.is_rate_limited is True
+
+    result2 = interface._detect_rate_limit("RATE LIMIT EXCEEDED")
+    assert result2.is_rate_limited is True
+
+
+def test_rate_limit_detected_quota_exceeded(interface):  # CLI-006
+    """'quota exceeded' pattern triggers is_rate_limited=True."""
+    result = interface._detect_rate_limit("quota exceeded for this billing period")
+    assert result.is_rate_limited is True
+
+
+def test_limit_exceeded_without_rate_qualifier_not_detected(interface):  # S11a
+    """Bare 'limit exceeded' without a rate/quota qualifier must NOT trigger
+    detection. The pattern was removed in S11a to prevent false positives from
+    system errors and tool output.
+    """
+    false_positive_strings = [
+        "API limit exceeded, try again later",
+        "Error: maximum recursion depth exceeded",
+        "MemoryError: memory limit exceeded",
+        "OSError: file size limit exceeded",
+        "stack limit exceeded during compilation",
+    ]
+    for text in false_positive_strings:
+        result = interface._detect_rate_limit(text)
+        assert result.is_rate_limited is False, (
+            f"False positive triggered by: {text!r}"
+        )
+
+
+def test_rate_limit_sets_limit_message_and_truncates(interface):  # CLI-008
+    """_detect_rate_limit() captures output as limit_message, truncated to 500 chars."""
+    long_output = "usage limit reached. " + "x" * 600
+    result = interface._detect_rate_limit(long_output)
+    assert result.is_rate_limited is True
+    assert result.limit_message != ""
+    assert len(result.limit_message) <= 500
+    assert "usage limit reached" in result.limit_message.lower()
+
+
+def test_rate_limit_detected_in_stderr(interface):  # CLI-009
+    """Rate-limit message in stderr is detected.
+
+    execute_prompt() passes result.stderr (only) to _detect_rate_limit(),
+    so messages in stderr are correctly caught.
+    """
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="usage limit reached"
+        )
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
+    assert result.rate_limit_info.is_rate_limited is True
+    assert result.success is False
+
+
+def test_rate_limit_detected_in_stderr_only(mocker):  # CLI-010
+    """Rate-limit phrase in stderr → is_rate_limited=True."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="usage limit reached"
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is True
+
+
+def test_rate_limit_in_stdout_only_not_detected(mocker):  # CLI-011
+    """Rate-limit phrase only in stdout → is_rate_limited=False (no false positive)."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="usage limit reached", stderr=""
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is False
+    assert result.success is True
+
+
+# ===========================================================================
+# Reset Time Parsing
+# ===========================================================================
+
+
+def test_extract_reset_time_parses_unix_pipe_format(interface):  # CLI-012
+    """'usage limit reached|<unix_ts>' is parsed to the correct datetime."""
+    ts = int(datetime(2025, 6, 1, 15, 0, 0).timestamp())
+    result = interface._extract_reset_time_from_limit_message(
+        f"usage limit reached|{ts}"
+    )
+    assert result is not None
+    delta = abs((result - datetime(2025, 6, 1, 15, 0, 0)).total_seconds())
+    assert delta < 2, f"Parsed time differs by {delta:.1f}s from expected"
+
+
+def test_extract_reset_time_falls_back_to_estimate(interface):  # CLI-013
+    """When no timestamp is found, the method falls back to _estimate_reset_time()
+    which always returns a future datetime.
+    """
+    result = interface._extract_reset_time_from_limit_message(
+        "usage limit reached (no timestamp here)"
+    )
+    assert result is not None
+    assert result > datetime.now(), (
+        "Fallback estimate must be a future datetime"
+    )
+
+
+def test_extract_reset_time_parses_iso_datetime(interface):  # CLI-014
+    """ISO datetime with Z suffix is parsed; the result is a naive datetime."""
+    iso_output = "usage limit reached. Resets at 2025-06-01T10:00:00Z."
+    result = interface._extract_reset_time_from_limit_message(iso_output)
+    assert result is not None
+    assert result.year == 2025
+    assert result.month == 6
+    assert result.tzinfo is None, "Result must be a naive datetime (no tzinfo)"
+
+
+# ===========================================================================
+# Reset Time Estimation
+# ===========================================================================
+#
+# _estimate_reset_time() never calls datetime() as a constructor — it only
+# calls datetime.now() and then uses .replace() / arithmetic on the result.
+# timedelta is imported separately and is NOT affected by the patch.
+#
+# Pattern for each test:
+#   with patch('claude_code_queue.claude_interface.datetime') as mock_dt:
+#       mock_dt.now.return_value = datetime(2025, 1, 1, HOUR, MINUTE, SECOND)
+#       result = interface._estimate_reset_time("")
+#   # assert OUTSIDE the with-block so the mock does not intercept datetime(...)
+#   assert result == datetime(2025, 1, EXPECTED_DAY, EXPECTED_HOUR, 0, 0)
+
+
+def test_estimate_reset_time_hour_0(interface):  # CLI-015
+    """00:30  →  05:00 today (first reset window)."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 0, 30, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 1, 5, 0, 0)
+
+
+def test_estimate_reset_time_hour_4(interface):  # CLI-016
+    """04:59  →  05:00 today (still before first window close)."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 4, 59, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 1, 5, 0, 0)
+
+
+def test_estimate_reset_time_hour_5(interface):  # CLI-017
+    """05:00  →  10:00 today (just entered the second window)."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 5, 0, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 1, 10, 0, 0)
+
+
+def test_estimate_reset_time_hour_9(interface):  # CLI-018
+    """09:59  →  10:00 today (still in second window)."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 9, 59, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 1, 10, 0, 0)
+
+
+def test_estimate_reset_time_hour_10(interface):  # CLI-019
+    """10:00  →  15:00 today (just entered the third window)."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 10, 0, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 1, 15, 0, 0)
+
+
+def test_estimate_reset_time_hour_15(interface):  # CLI-020
+    """15:00  →  20:00 today (just entered the fourth window)."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 15, 0, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 1, 20, 0, 0)
+
+
+def test_estimate_reset_time_hour_20(interface):  # CLI-021
+    """20:00  →  01:00 tomorrow."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 20, 0, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 2, 1, 0, 0)
+
+
+def test_estimate_reset_time_hour_23(interface):  # CLI-022
+    """23:59  →  01:00 tomorrow (same late-night window as 20:00)."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 23, 59, 0)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 2, 1, 0, 0)
+
+
+def test_estimate_reset_time_at_exact_boundary_hour_5(interface):  # CLI-023
+    """Exactly 05:00:00 (the >= 5 boundary) → 10:00 today."""
+    with patch("claude_code_queue.claude_interface.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2025, 1, 1, 5, 0, 0)
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = interface._estimate_reset_time("")
+    assert result == datetime(2025, 1, 1, 10, 0, 0)
+
+
+# ===========================================================================
+# Command Execution
+# ===========================================================================
+
+
+def test_execute_prompt_calls_claude_with_print_flag(interface):  # CLI-024
+    """execute_prompt() calls the claude binary with --print."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
+        interface.execute_prompt(QueuedPrompt(content="test task"))
+        args = mock_run.call_args[0][0]
+        assert "--print" in args
+
+
+def test_execute_prompt_includes_dangerously_skip_permissions(interface):  # CLI-025
+    """execute_prompt() includes --dangerously-skip-permissions in the command."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
+        interface.execute_prompt(QueuedPrompt(content="test task"))
+        args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" in args
+
+
+def test_execute_prompt_success_returns_success_result(interface):  # CLI-026
+    """returncode=0 with no rate-limit output → success=True."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="All done", stderr="")
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
+        assert result.success is True
+        assert result.output == "All done"
+
+
+def test_execute_prompt_failure_returns_failure_result(interface):  # CLI-027
+    """Non-zero returncode → success=False."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="Something went wrong"
+        )
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
+        assert result.success is False
+
+
+def test_execute_prompt_rate_limit_in_stdout_not_detected(interface):  # CLI-028
+    """Rate-limit text only in stdout is NOT detected (stderr-only detection)."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="usage limit reached", stderr=""
+        )
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
+        assert result.rate_limit_info.is_rate_limited is False
+        assert result.success is True
+
+
+def test_execute_prompt_with_context_files_includes_at_references(
+    interface, tmp_path
+):  # CLI-029
+    """Existing context_files entries are passed as '@filename' references."""
+    context_file = tmp_path / "README.md"
+    context_file.write_text("# README")
+
+    prompt = QueuedPrompt(
+        content="task",
+        working_directory=str(tmp_path),
+        context_files=["README.md"],
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        interface.execute_prompt(prompt)
+        call_args = mock_run.call_args[0][0]
+        full_cmd = " ".join(call_args)
+        assert "@README.md" in full_cmd, (
+            f"Expected '@README.md' in command args: {call_args}"
+        )
+
+
+def test_execute_prompt_uses_working_directory(interface, tmp_path):  # CLI-030
+    """execute_prompt() passes cwd= to subprocess.run instead of os.chdir()."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        prompt = QueuedPrompt(content="task", working_directory=str(tmp_path))
+        interface.execute_prompt(prompt)
+
+    expected = str(tmp_path.resolve())
+    call_kwargs = mock_run.call_args[1]
+    assert "cwd" in call_kwargs, (
+        f"Expected 'cwd' kwarg in subprocess.run call; got kwargs: {call_kwargs}"
+    )
+    assert call_kwargs["cwd"] == expected, (
+        f"Expected cwd={expected!r}; got cwd={call_kwargs['cwd']!r}"
+    )
+
+
+def test_execute_prompt_skips_nonexistent_context_files(interface, tmp_path):  # CLI-031
+    """Context file paths that don't exist on disk are omitted from the command."""
+    prompt = QueuedPrompt(
+        content="task",
+        working_directory=str(tmp_path),
+        context_files=["nonexistent.py", "also-missing.py"],
+    )
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        interface.execute_prompt(prompt)
+        call_args = mock_run.call_args[0][0]
+        full_cmd = " ".join(call_args)
+        assert "@nonexistent.py" not in full_cmd
+        assert "@also-missing.py" not in full_cmd
+
+
+def test_execute_prompt_timeout_returns_failure_result(interface):  # CLI-032
+    """subprocess.TimeoutExpired → success=False with 'timed out' in error."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=60)
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
+        assert result.success is False
+        assert "timed out" in result.error.lower(), (
+            f"Expected 'timed out' in error message, got: {result.error!r}"
+        )
+
+
+# ===========================================================================
+# Connection Testing
+# ===========================================================================
+
+
+def test_test_connection_returns_true_when_claude_available(interface):  # CLI-033
+    """test_connection() returns (True, msg) when the subprocess exits 0."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Claude Code v1.0", stderr=""
+        )
+        ok, msg = interface.test_connection()
+        assert ok is True
+
+
+def test_test_connection_returns_false_when_unavailable(interface):  # CLI-034
+    """test_connection() returns (False, msg) with 'not found' when FileNotFoundError."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = FileNotFoundError("claude not found")
+        ok, msg = interface.test_connection()
+        assert ok is False
+        assert "not found" in msg.lower(), (
+            f"Expected 'not found' in error message, got: {msg!r}"
+        )
+
+
+def test_version_warning_emitted_for_old_claude(mocker, capsys):  # CLI-035
+    """A version string older than (2,1,50) triggers a warning on stderr."""
+    mocker.patch(
+        "subprocess.run",
+        return_value=MagicMock(
+            returncode=0,
+            stdout="1.0.0 (Claude Code)",
+            stderr="",
+        ),
+    )
+    ClaudeCodeInterface(claude_command="claude", timeout=60)
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+    assert "2.1.50" in captured.err
+
+
+def test_version_warning_not_emitted_for_current_claude(mocker, capsys):  # CLI-036
+    """A version string >= (2,1,50) does NOT trigger a warning."""
+    mocker.patch(
+        "subprocess.run",
+        return_value=MagicMock(
+            returncode=0,
+            stdout="2.1.50 (Claude Code)",
+            stderr="",
+        ),
+    )
+    ClaudeCodeInterface(claude_command="claude", timeout=60)
+    captured = capsys.readouterr()
+    assert "Warning" not in captured.err
+
+
+# ===========================================================================
+# Security & Configuration
+# ===========================================================================
+
+
+def test_skip_permissions_true_includes_flag(mocker):  # CLI-037
+    """skip_permissions=True (default) → --dangerously-skip-permissions in cmd."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60, skip_permissions=True)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
+        iface.execute_prompt(QueuedPrompt(content="task"))
+        args = mock_run.call_args[0][0]
+
+    assert "--dangerously-skip-permissions" in args
+
+
+def test_skip_permissions_false_omits_flag(mocker):  # CLI-038
+    """skip_permissions=False → --dangerously-skip-permissions NOT in cmd."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60, skip_permissions=False)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
+        iface.execute_prompt(QueuedPrompt(content="task"))
+        args = mock_run.call_args[0][0]
+
+    assert "--dangerously-skip-permissions" not in args
+    assert "--print" in args
+
+
+def test_out_of_home_working_directory_emits_warning(mocker, tmp_path, capsys):  # CLI-039
+    """working_directory outside home → warning on stderr."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    prompt = QueuedPrompt(content="task", working_directory="/tmp")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("pathlib.Path.home", return_value=Path("/home/testuser")):
+            iface.execute_prompt(prompt)
+
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err or "warning" in captured.err.lower(), (
+        f"Expected a warning for out-of-home path, got stderr: {captured.err!r}"
+    )
+
+
+def test_in_home_working_directory_no_warning(mocker, tmp_path, capsys):  # CLI-040
+    """working_directory inside home → no warning on stderr."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    prompt = QueuedPrompt(content="task", working_directory=str(tmp_path))
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("pathlib.Path.home", return_value=tmp_path.parent):
+            iface.execute_prompt(prompt)
+
+    captured = capsys.readouterr()
+    assert "Warning" not in captured.err, (
+        f"Expected no warning for in-home path, got stderr: {captured.err!r}"
+    )
+
+
+def test_cap_reset_time_limits_far_future_timestamp(mocker):  # CLI-041
+    """reset_time far in the future is capped to <= 24 hours from now."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+
+    far_future = datetime.now() + timedelta(days=7)
+    capped = ClaudeCodeInterface._cap_reset_time(far_future)
+
+    max_allowed = datetime.now() + timedelta(hours=_RATE_LIMIT_MAX_RESET_HOURS)
+    assert capped <= max_allowed, (
+        f"Capped time {capped} exceeds allowed maximum {max_allowed}"
+    )
+    delta = (max_allowed - capped).total_seconds()
+    assert delta < 5, f"Capped time {capped} is not near the 24h cap"
+
+
+def test_cap_reset_time_strips_timezone_info(mocker):  # CLI-042
+    """_cap_reset_time() returns a naive datetime regardless of input tzinfo."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+
+    aware_dt = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+    result = ClaudeCodeInterface._cap_reset_time(aware_dt)
+
+    assert result.tzinfo is None, "Result must be a naive datetime (no tzinfo)"
+
+
+def test_extract_reset_time_caps_far_future_unix_timestamp(mocker):  # CLI-043
+    """A unix timestamp 7 days away is capped to <= 24h by _extract_reset_time."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    far_ts = int((datetime.now() + timedelta(days=7)).timestamp())
+    result = iface._extract_reset_time_from_limit_message(
+        f"usage limit reached|{far_ts}"
+    )
+
+    assert result is not None
+    max_allowed = datetime.now() + timedelta(hours=_RATE_LIMIT_MAX_RESET_HOURS)
+    assert result <= max_allowed, (
+        f"Reset time {result} not capped to <= {max_allowed}"
+    )
+
+
+def test_estimate_reset_time_caps_at_24h(mocker):  # CLI-044
+    """_estimate_reset_time() result is always <= 24 hours from now."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    result = iface._estimate_reset_time("")
+
+    max_allowed = datetime.now() + timedelta(hours=_RATE_LIMIT_MAX_RESET_HOURS)
+    assert result <= max_allowed + timedelta(seconds=1), (
+        f"Estimated reset {result} exceeds 24h cap {max_allowed}"
+    )
+
+
+# ===========================================================================
+# Scan-Window Depth Guard (S11b)
+# ===========================================================================
+
+
+def test_detect_rate_limit_ignores_phrase_beyond_scan_window(interface):  # S11b
+    """A rate-limit phrase that appears only AFTER _RATE_LIMIT_SCAN_CHARS characters
+    of stderr must NOT trigger detection.
+
+    Scenario: a long-running task invokes a subprocess whose verbose debug log
+    happens to contain 'quota exceeded' deep in its output. The depth cap
+    ensures this does not stall the queue.
+    """
+    prefix = "x" * _RATE_LIMIT_SCAN_CHARS  # pushes phrase to index _RATE_LIMIT_SCAN_CHARS
+    result = interface._detect_rate_limit(prefix + "\nquota exceeded")
+    assert result.is_rate_limited is False, (
+        "Pattern beyond scan window must not trigger rate-limit detection"
+    )
+
+
+def test_detect_rate_limit_still_fires_within_scan_window(interface):  # S11b
+    """A rate-limit phrase that appears WITHIN _RATE_LIMIT_SCAN_CHARS characters
+    is still detected correctly after the scan-window restriction.
+    """
+    result = interface._detect_rate_limit("quota exceeded for this billing period")
+    assert result.is_rate_limited is True
+
+
+def test_detect_rate_limit_fires_at_last_char_of_scan_window(interface):  # S11b
+    """A pattern whose final character sits at index _RATE_LIMIT_SCAN_CHARS - 1
+    (the last position inside the window) is still detected.
+
+    Validates the boundary is inclusive: output[:N] includes index N-1.
+    """
+    pattern = "quota exceeded"
+    # Pad prefix so pattern ends exactly at index _RATE_LIMIT_SCAN_CHARS - 1.
+    prefix = "x" * (_RATE_LIMIT_SCAN_CHARS - len(pattern))
+    result = interface._detect_rate_limit(prefix + pattern + "x" * 1000)
+    assert result.is_rate_limited is True, (
+        "Pattern ending at the last character of the scan window must still fire"
+    )
+
+
+# ===========================================================================
+# False-Positive Regression Suite (S11c)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("fp_text", [
+    # ------------------------------------------------------------------
+    # Group 1: no matching pattern — safe regardless of scan-window size
+    # ------------------------------------------------------------------
+    # Python runtime errors
+    "Traceback (most recent call last):\n  ...\nRecursionError: maximum recursion depth exceeded",
+    # Shell / OS errors
+    "bash: fork: retry: Resource temporarily unavailable",
+    "ulimit: file size: cannot modify limit: Operation not permitted",
+    # Compiler / linker output (contains "limit exceeded" — safe after S11a removes it)
+    "ld: warning: stack size limit exceeded, consider reducing stack usage",
+    # ------------------------------------------------------------------
+    # Group 2: live pattern buried beyond _RATE_LIMIT_SCAN_CHARS — tests S11b
+    # Short prose versions of these strings ARE accepted false positives for
+    # this pass (see "Known Remaining Limitation" in checklist).
+    # ------------------------------------------------------------------
+    pytest.param(
+        "x" * _RATE_LIMIT_SCAN_CHARS + "\nquota exceeded for external service",
+        id="quota-exceeded-beyond-scan-window",
+    ),
+    pytest.param(
+        "x" * _RATE_LIMIT_SCAN_CHARS + "\ntoo many requests to upstream service",
+        id="too-many-requests-beyond-scan-window",
+    ),
+])
+def test_false_positive_not_detected(interface, fp_text):  # S11c
+    """Common false-positive strings must NOT trigger rate-limit detection.
+
+    After R3, detection runs on stderr only; after S11a, 'limit exceeded' is
+    removed; after S11b, only the first _RATE_LIMIT_SCAN_CHARS characters are
+    scanned. This parametrized test guards against regression of any of those
+    hardening measures.
+    """
+    result = interface._detect_rate_limit(fp_text)
+    assert result.is_rate_limited is False, (
+        f"False positive triggered by:\n  {fp_text!r}"
+    )

--- a/tests/test_claude_interface.py
+++ b/tests/test_claude_interface.py
@@ -643,6 +643,18 @@ def test_detect_rate_limit_fires_at_last_char_of_scan_window(interface):  # S11b
         "x" * _RATE_LIMIT_SCAN_CHARS + "\ntoo many requests to upstream service",
         id="too-many-requests-beyond-scan-window",
     ),
+    pytest.param(
+        "x" * _RATE_LIMIT_SCAN_CHARS + "\nyou are rate limited by upstream proxy",
+        id="rate-limited-beyond-scan-window",
+    ),
+    pytest.param(
+        "x" * _RATE_LIMIT_SCAN_CHARS + '\nsome internal rate_limit_error in debug log',
+        id="rate-limit-error-beyond-scan-window",
+    ),
+    pytest.param(
+        "x" * _RATE_LIMIT_SCAN_CHARS + "\nrate limit exceeded for third-party API",
+        id="rate-limit-exceeded-beyond-scan-window",
+    ),
 ])
 def test_false_positive_not_detected(interface, fp_text):  # S11c
     """Common false-positive strings must NOT trigger rate-limit detection.
@@ -803,3 +815,254 @@ def test_get_available_commands_strips_claudecode_from_env(interface, monkeypatc
         interface.get_available_commands()
     _, kwargs = mock_run.call_args
     assert "CLAUDECODE" not in kwargs["env"]
+
+
+# ===========================================================================
+# Fix 1 — Broader Rate-Limit Pattern Coverage
+# ===========================================================================
+
+
+def test_rate_limit_detected_exceeded_your_rate_limit(interface):  # CLI-045
+    """'exceeded your rate limit' pattern triggers is_rate_limited=True."""
+    result = interface._detect_rate_limit(
+        "Error: you have exceeded your rate limit. Please wait before retrying."
+    )
+    assert result.is_rate_limited is True
+
+
+def test_rate_limit_detected_rate_limit_error_api_type(interface):  # CLI-046
+    """'rate_limit_error' (Anthropic API error type) triggers is_rate_limited=True.
+
+    Uses default broad_patterns=True (stderr context). This pattern is gated
+    behind broad_patterns and will NOT fire with broad_patterns=False (stdout
+    context) — see CLI-049c.
+    """
+    result = interface._detect_rate_limit(
+        'error type: "rate_limit_error", please reduce request frequency'
+    )
+    assert result.is_rate_limited is True
+
+
+def test_rate_limit_detected_youve_reached_your(interface):  # CLI-047
+    """'you've reached your' pattern triggers is_rate_limited=True."""
+    result = interface._detect_rate_limit(
+        "You've reached your usage limit. Your limit will reset at the next window."
+    )
+    assert result.is_rate_limited is True
+
+
+def test_rate_limit_detected_rate_limited(interface):  # CLI-048
+    """'rate limited' (past participle) triggers is_rate_limited=True with broad_patterns=True."""
+    result = interface._detect_rate_limit(
+        "You are rate limited. Please try again later.",
+        broad_patterns=True,
+    )
+    assert result.is_rate_limited is True
+
+
+def test_rate_limited_not_detected_broad_patterns_false(interface):  # CLI-049
+    """'rate limited' is NOT detected when broad_patterns=False.
+
+    Validates the stdout-scan guard: subprocess output that contains 'rate limited'
+    must not trigger a false-positive rate-limit detection when the caller passes
+    broad_patterns=False (as Fix 2's stdout tail scan does).
+    """
+    result = interface._detect_rate_limit(
+        "npm ERR! 429 you are rate limited by the registry. retry after 60s",
+        broad_patterns=False,
+    )
+    assert result.is_rate_limited is False, (
+        "Broad 'rate limited' pattern must not fire when broad_patterns=False"
+    )
+
+
+def test_stdout_safe_pattern_still_fires_broad_patterns_false(interface):  # CLI-049b
+    """Stdout-safe patterns (e.g. 'usage limit reached') still fire when broad_patterns=False."""
+    result = interface._detect_rate_limit(
+        "usage limit reached|9999999999",
+        broad_patterns=False,
+    )
+    assert result.is_rate_limited is True, (
+        "Stdout-safe patterns must remain active regardless of broad_patterns flag"
+    )
+
+
+@pytest.mark.parametrize("broad_phrase", [
+    pytest.param("rate limit exceeded", id="rate-limit-exceeded"),
+    pytest.param("rate_limit_error", id="rate-limit-error-api-type"),
+    pytest.param("too many requests", id="too-many-requests"),
+    pytest.param("quota exceeded", id="quota-exceeded"),
+    pytest.param("rate limited", id="rate-limited"),
+])
+def test_broad_patterns_not_detected_when_false(interface, broad_phrase):  # CLI-049c
+    """All broad patterns must NOT fire when broad_patterns=False.
+
+    Each of these phrases can appear in subprocess output (npm, pip, curl,
+    cloud CLIs, or user-generated code). When broad_patterns=False (stdout
+    scanning context), they must not trigger a false-positive ~5-hour hold.
+    """
+    result = interface._detect_rate_limit(
+        f"Error: {broad_phrase}. Please try again later.",
+        broad_patterns=False,
+    )
+    assert result.is_rate_limited is False, (
+        f"Broad pattern {broad_phrase!r} must not fire when broad_patterns=False"
+    )
+
+
+# ===========================================================================
+# Fix 2 — Stdout Scanning on Non-Zero Return
+# ===========================================================================
+
+
+def test_rate_limit_in_stdout_detected_when_returncode_nonzero(mocker):  # CLI-050
+    """Rate-limit phrase only in stdout is detected when returncode != 0.
+
+    Scenario: mid-execution rate-limit causes CLI to emit notice on stdout
+    (conversation stream) then exit 1.
+    """
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    future_ts = int(datetime.now().timestamp()) + 7200
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout=f"usage limit reached|{future_ts}", stderr=""
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is True
+    assert result.success is False
+    assert result.rate_limit_info.reset_time is not None
+    assert result.rate_limit_info.reset_time > datetime.now()
+    assert result.rate_limit_info.detection_source == "stdout", (
+        "Stdout-detected rate limits must set detection_source='stdout'"
+    )
+
+
+def test_rate_limit_in_stdout_tail_detected_when_returncode_nonzero(mocker):  # CLI-054
+    """Rate-limit phrase buried at the end of long stdout is detected when returncode != 0.
+
+    Scenario: a long-running conversation (many chars of output) hits a rate limit.
+    The rate-limit notice appears at the very end of stdout — past the first
+    _RATE_LIMIT_SCAN_CHARS characters. The tail-scan in execute_prompt() must find it.
+    """
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    future_ts = int(datetime.now().timestamp()) + 7200
+    long_conversation = "x" * (_RATE_LIMIT_SCAN_CHARS * 3)
+    stdout_with_tail_notice = long_conversation + f"\nusage limit reached|{future_ts}"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout=stdout_with_tail_notice, stderr=""
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is True, (
+        "Rate-limit notice at the tail of long stdout must be detected"
+    )
+    assert result.success is False
+
+
+def test_rate_limit_in_stdout_not_detected_when_returncode_zero(mocker):  # CLI-051
+    """Rate-limit phrase in stdout is NOT detected when returncode=0.
+
+    This is the R3 guard: a successful Claude response that discusses rate
+    limits in its text must not be misidentified.
+    """
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Here is how to handle rate limit exceeded errors in your code.",
+            stderr=""
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is False
+    assert result.success is True
+
+
+def test_rate_limit_stderr_takes_priority_over_stdout(mocker):  # CLI-052
+    """When both stderr and stdout contain rate-limit text and returncode != 0,
+    the stderr detection wins (stdout scan is not reached when stderr matches).
+    """
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="usage limit reached|111",
+            stderr="rate limit exceeded"
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is True
+
+
+def test_no_rate_limit_empty_stdout_nonzero_return(mocker):  # CLI-053
+    """Empty stdout with returncode != 0 and no rate-limit text → not rate-limited."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="Something went wrong"
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is False
+
+
+def test_subprocess_rate_limited_phrase_in_stdout_not_misidentified(mocker):  # CLI-055
+    """Subprocess output containing 'rate limited' in stdout does NOT trigger
+    rate-limit detection when returncode != 0.
+
+    Scenario: Claude runs a task that invokes npm. npm exits with an error that
+    includes 'rate limited by registry'. Claude exits non-zero because npm failed.
+    Without broad_patterns=False in the stdout scan, this would be misidentified
+    as a Claude API rate limit, triggering a ~5-hour hold.
+    """
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="npm ERR! code E429\nnpm ERR! you are rate limited by the npm registry",
+            stderr="",
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is False, (
+        "Subprocess 'rate limited' phrase in stdout must not trigger Claude API "
+        "rate-limit detection (broad_patterns=False guard)"
+    )
+    assert result.success is False  # execution did fail, just not from a rate limit
+
+
+def test_rate_limit_error_string_in_user_code_stdout_not_misidentified(mocker):  # CLI-056
+    """'rate_limit_error' appearing in Claude-generated code does NOT trigger
+    rate-limit detection when returncode != 0 (e.g., a downstream test runner fails).
+    """
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout='if error_type == "rate_limit_error":\n    handle_rate_limit()',
+            stderr="",
+        )
+        result = iface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.rate_limit_info.is_rate_limited is False, (
+        "'rate_limit_error' in user code echoed to stdout must not trigger "
+        "Claude API rate-limit detection"
+    )
+    assert result.success is False  # process did fail, but not from a rate limit

--- a/tests/test_claude_interface.py
+++ b/tests/test_claude_interface.py
@@ -6,6 +6,7 @@ so the constructor never actually calls the claude binary.
 """
 
 import subprocess
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -18,8 +19,32 @@ from claude_code_queue.claude_interface import (
     _RATE_LIMIT_SCAN_CHARS,
     _NON_RETRYABLE_SCAN_CHARS,
     _NON_RETRYABLE_PATTERNS,
+    _SIGKILL,
+    _SIGTERM,
 )
 from claude_code_queue.models import QueuedPrompt, RateLimitInfo, PromptStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_mock_proc(returncode=0, stdout="done", stderr="", pid=99999):
+    """Create a mock Popen object with sensible defaults for all attributes
+    the production code touches.
+
+    IMPORTANT: ``pid`` must be an int (not MagicMock) — ``os.killpg()``
+    raises ``TypeError`` for non-int values.  ``wait()`` returns the
+    returncode so the escalation thread's ``p.wait(timeout=...)`` behaves
+    correctly (returns an int, not a MagicMock).
+    """
+    proc = MagicMock()
+    proc.communicate.return_value = (stdout, stderr)
+    proc.returncode = returncode
+    proc.pid = pid
+    proc.wait.return_value = returncode
+    return proc
 
 
 # ===========================================================================
@@ -105,39 +130,27 @@ def test_rate_limit_detected_in_stderr(interface):  # CLI-009
     execute_prompt() passes result.stderr (only) to _detect_rate_limit(),
     so messages in stderr are correctly caught.
     """
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="usage limit reached"
-        )
+    mock_proc = make_mock_proc(returncode=1, stdout="", stderr="usage limit reached")
+    with patch("subprocess.Popen", return_value=mock_proc):
         result = interface.execute_prompt(QueuedPrompt(content="task"))
     assert result.rate_limit_info.is_rate_limited is True
     assert result.success is False
 
 
-def test_rate_limit_detected_in_stderr_only(mocker):  # CLI-010
+def test_rate_limit_detected_in_stderr_only(interface):  # CLI-010
     """Rate-limit phrase in stderr → is_rate_limited=True."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="usage limit reached"
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(returncode=1, stdout="", stderr="usage limit reached")
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is True
 
 
-def test_rate_limit_in_stdout_only_not_detected(mocker):  # CLI-011
+def test_rate_limit_in_stdout_only_not_detected(interface):  # CLI-011
     """Rate-limit phrase only in stdout → is_rate_limited=False (no false positive)."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="usage limit reached", stderr=""
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(returncode=0, stdout="usage limit reached", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is False
     assert result.success is True
@@ -278,26 +291,26 @@ def test_estimate_reset_time_at_exact_boundary_hour_5(interface):  # CLI-023
 
 def test_execute_prompt_calls_claude_with_print_flag(interface):  # CLI-024
     """execute_prompt() calls the claude binary with --print."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
+    mock_proc = make_mock_proc()
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         interface.execute_prompt(QueuedPrompt(content="test task"))
-        args = mock_run.call_args[0][0]
+        args = mock_popen.call_args[0][0]
         assert "--print" in args
 
 
 def test_execute_prompt_includes_dangerously_skip_permissions(interface):  # CLI-025
     """execute_prompt() includes --dangerously-skip-permissions in the command."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
+    mock_proc = make_mock_proc()
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         interface.execute_prompt(QueuedPrompt(content="test task"))
-        args = mock_run.call_args[0][0]
+        args = mock_popen.call_args[0][0]
         assert "--dangerously-skip-permissions" in args
 
 
 def test_execute_prompt_success_returns_success_result(interface):  # CLI-026
     """returncode=0 with no rate-limit output → success=True."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="All done", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="All done", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc):
         result = interface.execute_prompt(QueuedPrompt(content="task"))
         assert result.success is True
         assert result.output == "All done"
@@ -305,20 +318,16 @@ def test_execute_prompt_success_returns_success_result(interface):  # CLI-026
 
 def test_execute_prompt_failure_returns_failure_result(interface):  # CLI-027
     """Non-zero returncode → success=False."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="Something went wrong"
-        )
+    mock_proc = make_mock_proc(returncode=1, stdout="", stderr="Something went wrong")
+    with patch("subprocess.Popen", return_value=mock_proc):
         result = interface.execute_prompt(QueuedPrompt(content="task"))
         assert result.success is False
 
 
 def test_execute_prompt_rate_limit_in_stdout_not_detected(interface):  # CLI-028
     """Rate-limit text only in stdout is NOT detected (stderr-only detection)."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="usage limit reached", stderr=""
-        )
+    mock_proc = make_mock_proc(returncode=0, stdout="usage limit reached", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc):
         result = interface.execute_prompt(QueuedPrompt(content="task"))
         assert result.rate_limit_info.is_rate_limited is False
         assert result.success is True
@@ -337,10 +346,10 @@ def test_execute_prompt_with_context_files_includes_at_references(
         context_files=["README.md"],
     )
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         interface.execute_prompt(prompt)
-        call_args = mock_run.call_args[0][0]
+        call_args = mock_popen.call_args[0][0]
         full_cmd = " ".join(call_args)
         assert "@README.md" in full_cmd, (
             f"Expected '@README.md' in command args: {call_args}"
@@ -348,16 +357,16 @@ def test_execute_prompt_with_context_files_includes_at_references(
 
 
 def test_execute_prompt_uses_working_directory(interface, tmp_path):  # CLI-030
-    """execute_prompt() passes cwd= to subprocess.run instead of os.chdir()."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    """execute_prompt() passes cwd= to subprocess.Popen instead of os.chdir()."""
+    mock_proc = make_mock_proc(returncode=0, stdout="", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         prompt = QueuedPrompt(content="task", working_directory=str(tmp_path))
         interface.execute_prompt(prompt)
 
     expected = str(tmp_path.resolve())
-    call_kwargs = mock_run.call_args[1]
+    call_kwargs = mock_popen.call_args[1]
     assert "cwd" in call_kwargs, (
-        f"Expected 'cwd' kwarg in subprocess.run call; got kwargs: {call_kwargs}"
+        f"Expected 'cwd' kwarg in subprocess.Popen call; got kwargs: {call_kwargs}"
     )
     assert call_kwargs["cwd"] == expected, (
         f"Expected cwd={expected!r}; got cwd={call_kwargs['cwd']!r}"
@@ -371,10 +380,10 @@ def test_execute_prompt_skips_nonexistent_context_files(interface, tmp_path):  #
         working_directory=str(tmp_path),
         context_files=["nonexistent.py", "also-missing.py"],
     )
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         interface.execute_prompt(prompt)
-        call_args = mock_run.call_args[0][0]
+        call_args = mock_popen.call_args[0][0]
         full_cmd = " ".join(call_args)
         assert "@nonexistent.py" not in full_cmd
         assert "@also-missing.py" not in full_cmd
@@ -382,13 +391,17 @@ def test_execute_prompt_skips_nonexistent_context_files(interface, tmp_path):  #
 
 def test_execute_prompt_timeout_returns_failure_result(interface):  # CLI-032
     """subprocess.TimeoutExpired → success=False with 'timed out' in error."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=60)
+    mock_proc = make_mock_proc()
+    mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=60)
+
+    with patch("subprocess.Popen", return_value=mock_proc), \
+         patch.object(ClaudeCodeInterface, "_kill_proc_group"):
         result = interface.execute_prompt(QueuedPrompt(content="task"))
-        assert result.success is False
-        assert "timed out" in result.error.lower(), (
-            f"Expected 'timed out' in error message, got: {result.error!r}"
-        )
+
+    assert result.success is False
+    assert "timed out" in result.error.lower(), (
+        f"Expected 'timed out' in error message, got: {result.error!r}"
+    )
 
 
 # ===========================================================================
@@ -427,7 +440,8 @@ def test_version_warning_emitted_for_old_claude(mocker, capsys):  # CLI-035
             stderr="",
         ),
     )
-    ClaudeCodeInterface(claude_command="claude", timeout=60)
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+    iface.close()
     captured = capsys.readouterr()
     assert "Warning" in captured.err
     assert "2.1.50" in captured.err
@@ -443,7 +457,8 @@ def test_version_warning_not_emitted_for_current_claude(mocker, capsys):  # CLI-
             stderr="",
         ),
     )
-    ClaudeCodeInterface(claude_command="claude", timeout=60)
+    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+    iface.close()
     captured = capsys.readouterr()
     assert "Warning" not in captured.err
 
@@ -453,15 +468,12 @@ def test_version_warning_not_emitted_for_current_claude(mocker, capsys):  # CLI-
 # ===========================================================================
 
 
-def test_skip_permissions_true_includes_flag(mocker):  # CLI-037
+def test_skip_permissions_true_includes_flag(interface):  # CLI-037
     """skip_permissions=True (default) → --dangerously-skip-permissions in cmd."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60, skip_permissions=True)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
-        iface.execute_prompt(QueuedPrompt(content="task"))
-        args = mock_run.call_args[0][0]
+    mock_proc = make_mock_proc()
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
+        interface.execute_prompt(QueuedPrompt(content="task"))
+        args = mock_popen.call_args[0][0]
 
     assert "--dangerously-skip-permissions" in args
 
@@ -471,26 +483,24 @@ def test_skip_permissions_false_omits_flag(mocker):  # CLI-038
     mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
     iface = ClaudeCodeInterface(claude_command="claude", timeout=60, skip_permissions=False)
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="done", stderr="")
+    mock_proc = make_mock_proc()
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         iface.execute_prompt(QueuedPrompt(content="task"))
-        args = mock_run.call_args[0][0]
+        args = mock_popen.call_args[0][0]
 
+    iface.close()
     assert "--dangerously-skip-permissions" not in args
     assert "--print" in args
 
 
-def test_out_of_home_working_directory_emits_warning(mocker, tmp_path, capsys):  # CLI-039
+def test_out_of_home_working_directory_emits_warning(interface, tmp_path, capsys):  # CLI-039
     """working_directory outside home → warning on stderr."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
     prompt = QueuedPrompt(content="task", working_directory="/tmp")
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc):
         with patch("pathlib.Path.home", return_value=Path("/home/testuser")):
-            iface.execute_prompt(prompt)
+            interface.execute_prompt(prompt)
 
     captured = capsys.readouterr()
     assert "Warning" in captured.err or "warning" in captured.err.lower(), (
@@ -498,17 +508,14 @@ def test_out_of_home_working_directory_emits_warning(mocker, tmp_path, capsys): 
     )
 
 
-def test_in_home_working_directory_no_warning(mocker, tmp_path, capsys):  # CLI-040
+def test_in_home_working_directory_no_warning(interface, tmp_path, capsys):  # CLI-040
     """working_directory inside home → no warning on stderr."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
     prompt = QueuedPrompt(content="task", working_directory=str(tmp_path))
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc):
         with patch("pathlib.Path.home", return_value=tmp_path.parent):
-            iface.execute_prompt(prompt)
+            interface.execute_prompt(prompt)
 
     captured = capsys.readouterr()
     assert "Warning" not in captured.err, (
@@ -516,10 +523,8 @@ def test_in_home_working_directory_no_warning(mocker, tmp_path, capsys):  # CLI-
     )
 
 
-def test_cap_reset_time_limits_far_future_timestamp(mocker):  # CLI-041
+def test_cap_reset_time_limits_far_future_timestamp(interface):  # CLI-041
     """reset_time far in the future is capped to <= 24 hours from now."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-
     far_future = datetime.now() + timedelta(days=7)
     capped = ClaudeCodeInterface._cap_reset_time(far_future)
 
@@ -531,23 +536,18 @@ def test_cap_reset_time_limits_far_future_timestamp(mocker):  # CLI-041
     assert delta < 5, f"Capped time {capped} is not near the 24h cap"
 
 
-def test_cap_reset_time_strips_timezone_info(mocker):  # CLI-042
+def test_cap_reset_time_strips_timezone_info(interface):  # CLI-042
     """_cap_reset_time() returns a naive datetime regardless of input tzinfo."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-
     aware_dt = datetime.now(tz=timezone.utc) + timedelta(hours=1)
     result = ClaudeCodeInterface._cap_reset_time(aware_dt)
 
     assert result.tzinfo is None, "Result must be a naive datetime (no tzinfo)"
 
 
-def test_extract_reset_time_caps_far_future_unix_timestamp(mocker):  # CLI-043
+def test_extract_reset_time_caps_far_future_unix_timestamp(interface):  # CLI-043
     """A unix timestamp 7 days away is capped to <= 24h by _extract_reset_time."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
     far_ts = int((datetime.now() + timedelta(days=7)).timestamp())
-    result = iface._extract_reset_time_from_limit_message(
+    result = interface._extract_reset_time_from_limit_message(
         f"usage limit reached|{far_ts}"
     )
 
@@ -558,12 +558,9 @@ def test_extract_reset_time_caps_far_future_unix_timestamp(mocker):  # CLI-043
     )
 
 
-def test_estimate_reset_time_caps_at_24h(mocker):  # CLI-044
+def test_estimate_reset_time_caps_at_24h(interface):  # CLI-044
     """_estimate_reset_time() result is always <= 24 hours from now."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    result = iface._estimate_reset_time("")
+    result = interface._estimate_reset_time("")
 
     max_allowed = datetime.now() + timedelta(hours=_RATE_LIMIT_MAX_RESET_HOURS)
     assert result <= max_allowed + timedelta(seconds=1), (
@@ -705,10 +702,8 @@ def test_execute_prompt_sets_is_non_retryable_on_nested_session_error(interface)
         "Error: Claude Code cannot be launched inside another Claude Code session.\n"
         "To bypass this check, unset the CLAUDECODE environment variable."
     )
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr=nested_session_stderr
-        )
+    mock_proc = make_mock_proc(returncode=1, stdout="", stderr=nested_session_stderr)
+    with patch("subprocess.Popen", return_value=mock_proc):
         result = interface.execute_prompt(QueuedPrompt(content="test"))
     assert result.is_non_retryable is True
     assert result.success is False
@@ -716,10 +711,8 @@ def test_execute_prompt_sets_is_non_retryable_on_nested_session_error(interface)
 
 def test_execute_prompt_is_non_retryable_false_for_ordinary_failure(interface):  # CLI-NR-005
     """ExecutionResult.is_non_retryable is False for retryable subprocess errors."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="some random error"
-        )
+    mock_proc = make_mock_proc(returncode=1, stdout="", stderr="some random error")
+    with patch("subprocess.Popen", return_value=mock_proc):
         result = interface.execute_prompt(QueuedPrompt(content="test"))
     assert result.is_non_retryable is False
 
@@ -755,10 +748,10 @@ def test_detect_non_retryable_error_fires_at_last_char_of_scan_window(interface)
 def test_execute_prompt_strips_claudecode_from_env(interface, monkeypatch):  # CLI-ENV-001
     """CLAUDECODE is removed from the subprocess environment."""
     monkeypatch.setenv("CLAUDECODE", "1")
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="ok", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         interface.execute_prompt(QueuedPrompt(content="test"))
-    _, kwargs = mock_run.call_args
+    _, kwargs = mock_popen.call_args
     assert "CLAUDECODE" not in kwargs["env"]
 
 
@@ -766,10 +759,10 @@ def test_execute_prompt_preserves_other_env_vars(interface, monkeypatch):  # CLI
     """Other environment variables (e.g. PATH, HOME) are passed through unchanged."""
     monkeypatch.setenv("CLAUDECODE", "1")
     monkeypatch.setenv("MY_CUSTOM_VAR", "hello")
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="ok", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         interface.execute_prompt(QueuedPrompt(content="test"))
-    _, kwargs = mock_run.call_args
+    _, kwargs = mock_popen.call_args
     assert "MY_CUSTOM_VAR" in kwargs["env"]
     assert kwargs["env"]["MY_CUSTOM_VAR"] == "hello"
     assert "PATH" in kwargs["env"]
@@ -778,10 +771,10 @@ def test_execute_prompt_preserves_other_env_vars(interface, monkeypatch):  # CLI
 def test_execute_prompt_env_strip_noop_when_claudecode_absent(interface, monkeypatch):  # CLI-ENV-003
     """If CLAUDECODE is not set, the env passed to subprocess is otherwise intact."""
     monkeypatch.delenv("CLAUDECODE", raising=False)
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+    mock_proc = make_mock_proc(returncode=0, stdout="ok", stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
         interface.execute_prompt(QueuedPrompt(content="test"))
-    _, kwargs = mock_run.call_args
+    _, kwargs = mock_popen.call_args
     assert "CLAUDECODE" not in kwargs["env"]
     assert "PATH" in kwargs["env"]  # rest of env is intact
 
@@ -791,7 +784,8 @@ def test_verify_claude_available_strips_claudecode_from_env(mocker, monkeypatch)
     monkeypatch.setenv("CLAUDECODE", "1")
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="2.1.50 (Claude Code)", stderr="")
-        ClaudeCodeInterface(claude_command="claude", timeout=60)
+        iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
+        iface.close()
     _, kwargs = mock_run.call_args
     assert "env" in kwargs
     assert "CLAUDECODE" not in kwargs["env"]
@@ -915,21 +909,18 @@ def test_broad_patterns_not_detected_when_false(interface, broad_phrase):  # CLI
 # ===========================================================================
 
 
-def test_rate_limit_in_stdout_detected_when_returncode_nonzero(mocker):  # CLI-050
+def test_rate_limit_in_stdout_detected_when_returncode_nonzero(interface):  # CLI-050
     """Rate-limit phrase only in stdout is detected when returncode != 0.
 
     Scenario: mid-execution rate-limit causes CLI to emit notice on stdout
     (conversation stream) then exit 1.
     """
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
     future_ts = int(datetime.now().timestamp()) + 7200
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout=f"usage limit reached|{future_ts}", stderr=""
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(
+        returncode=1, stdout=f"usage limit reached|{future_ts}", stderr=""
+    )
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is True
     assert result.success is False
@@ -940,25 +931,20 @@ def test_rate_limit_in_stdout_detected_when_returncode_nonzero(mocker):  # CLI-0
     )
 
 
-def test_rate_limit_in_stdout_tail_detected_when_returncode_nonzero(mocker):  # CLI-054
+def test_rate_limit_in_stdout_tail_detected_when_returncode_nonzero(interface):  # CLI-054
     """Rate-limit phrase buried at the end of long stdout is detected when returncode != 0.
 
     Scenario: a long-running conversation (many chars of output) hits a rate limit.
     The rate-limit notice appears at the very end of stdout — past the first
     _RATE_LIMIT_SCAN_CHARS characters. The tail-scan in execute_prompt() must find it.
     """
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
     future_ts = int(datetime.now().timestamp()) + 7200
     long_conversation = "x" * (_RATE_LIMIT_SCAN_CHARS * 3)
     stdout_with_tail_notice = long_conversation + f"\nusage limit reached|{future_ts}"
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout=stdout_with_tail_notice, stderr=""
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(returncode=1, stdout=stdout_with_tail_notice, stderr="")
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is True, (
         "Rate-limit notice at the tail of long stdout must be detected"
@@ -966,60 +952,49 @@ def test_rate_limit_in_stdout_tail_detected_when_returncode_nonzero(mocker):  # 
     assert result.success is False
 
 
-def test_rate_limit_in_stdout_not_detected_when_returncode_zero(mocker):  # CLI-051
+def test_rate_limit_in_stdout_not_detected_when_returncode_zero(interface):  # CLI-051
     """Rate-limit phrase in stdout is NOT detected when returncode=0.
 
     This is the R3 guard: a successful Claude response that discusses rate
     limits in its text must not be misidentified.
     """
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="Here is how to handle rate limit exceeded errors in your code.",
-            stderr=""
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(
+        returncode=0,
+        stdout="Here is how to handle rate limit exceeded errors in your code.",
+        stderr=""
+    )
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is False
     assert result.success is True
 
 
-def test_rate_limit_stderr_takes_priority_over_stdout(mocker):  # CLI-052
+def test_rate_limit_stderr_takes_priority_over_stdout(interface):  # CLI-052
     """When both stderr and stdout contain rate-limit text and returncode != 0,
     the stderr detection wins (stdout scan is not reached when stderr matches).
     """
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stdout="usage limit reached|111",
-            stderr="rate limit exceeded"
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(
+        returncode=1,
+        stdout="usage limit reached|111",
+        stderr="rate limit exceeded"
+    )
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is True
 
 
-def test_no_rate_limit_empty_stdout_nonzero_return(mocker):  # CLI-053
+def test_no_rate_limit_empty_stdout_nonzero_return(interface):  # CLI-053
     """Empty stdout with returncode != 0 and no rate-limit text → not rate-limited."""
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="Something went wrong"
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(returncode=1, stdout="", stderr="Something went wrong")
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is False
 
 
-def test_subprocess_rate_limited_phrase_in_stdout_not_misidentified(mocker):  # CLI-055
+def test_subprocess_rate_limited_phrase_in_stdout_not_misidentified(interface):  # CLI-055
     """Subprocess output containing 'rate limited' in stdout does NOT trigger
     rate-limit detection when returncode != 0.
 
@@ -1028,16 +1003,13 @@ def test_subprocess_rate_limited_phrase_in_stdout_not_misidentified(mocker):  # 
     Without broad_patterns=False in the stdout scan, this would be misidentified
     as a Claude API rate limit, triggering a ~5-hour hold.
     """
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stdout="npm ERR! code E429\nnpm ERR! you are rate limited by the npm registry",
-            stderr="",
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(
+        returncode=1,
+        stdout="npm ERR! code E429\nnpm ERR! you are rate limited by the npm registry",
+        stderr="",
+    )
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is False, (
         "Subprocess 'rate limited' phrase in stdout must not trigger Claude API "
@@ -1046,23 +1018,147 @@ def test_subprocess_rate_limited_phrase_in_stdout_not_misidentified(mocker):  # 
     assert result.success is False  # execution did fail, just not from a rate limit
 
 
-def test_rate_limit_error_string_in_user_code_stdout_not_misidentified(mocker):  # CLI-056
+def test_rate_limit_error_string_in_user_code_stdout_not_misidentified(interface):  # CLI-056
     """'rate_limit_error' appearing in Claude-generated code does NOT trigger
     rate-limit detection when returncode != 0 (e.g., a downstream test runner fails).
     """
-    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
-    iface = ClaudeCodeInterface(claude_command="claude", timeout=60)
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stdout='if error_type == "rate_limit_error":\n    handle_rate_limit()',
-            stderr="",
-        )
-        result = iface.execute_prompt(QueuedPrompt(content="task"))
+    mock_proc = make_mock_proc(
+        returncode=1,
+        stdout='if error_type == "rate_limit_error":\n    handle_rate_limit()',
+        stderr="",
+    )
+    with patch("subprocess.Popen", return_value=mock_proc):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
 
     assert result.rate_limit_info.is_rate_limited is False, (
         "'rate_limit_error' in user code echoed to stdout must not trigger "
         "Claude API rate-limit detection"
     )
     assert result.success is False  # process did fail, but not from a rate limit
+
+
+# ===========================================================================
+# Interrupt / Kill Tests (CLI-INT)
+# ===========================================================================
+
+
+def test_kill_current_with_no_running_process(interface):  # CLI-INT-001
+    """kill_current() with no running process does not raise."""
+    interface.kill_current()  # should not raise
+
+
+def test_kill_current_sends_sigterm_and_sets_interrupted(interface):  # CLI-INT-002
+    """kill_current() calls _kill_proc_group(proc, _SIGTERM) and sets _interrupted."""
+    mock_proc = MagicMock()
+    mock_proc.pid = 99999
+    mock_proc.wait.return_value = 0  # leader exits quickly from SIGTERM
+    interface._current_process = mock_proc
+
+    with patch.object(ClaudeCodeInterface, "_kill_proc_group", return_value=True) as mock_kpg:
+        interface.kill_current()
+
+    mock_kpg.assert_any_call(mock_proc, _SIGTERM)
+    assert interface._interrupted is True
+    assert interface._escalate_thread is not None
+
+
+def test_kill_current_escalates_to_sigkill_on_timeout(interface):  # CLI-INT-003
+    """kill_current() escalates to SIGKILL when p.wait() times out."""
+    escalated = threading.Event()
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 99999
+    mock_proc.wait.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=3)
+
+    call_log = []
+
+    def mock_kill_proc_group(proc, sig):
+        call_log.append(sig)
+        if sig == _SIGKILL:
+            escalated.set()
+        return True
+
+    interface._current_process = mock_proc
+
+    with patch.object(ClaudeCodeInterface, "_kill_proc_group", side_effect=mock_kill_proc_group):
+        interface.kill_current()
+
+    assert escalated.wait(timeout=2), "Escalation thread did not fire SIGKILL within 2 s"
+    interface._escalate_thread.join(timeout=1)
+    assert not interface._escalate_thread.is_alive()
+    assert call_log == [_SIGTERM, _SIGKILL], f"Expected SIGTERM then SIGKILL, got {call_log}"
+
+
+def test_kill_current_returns_early_when_process_already_gone(interface):  # CLI-INT-004
+    """kill_current() returns early when _kill_proc_group returns False."""
+    mock_proc = MagicMock()
+    mock_proc.pid = 99999
+    interface._current_process = mock_proc
+
+    with patch.object(ClaudeCodeInterface, "_kill_proc_group", return_value=False):
+        interface.kill_current()
+
+    assert interface._interrupted is False
+    assert interface._escalate_thread is None
+
+
+def test_execute_prompt_raises_keyboard_interrupt_when_interrupted(interface):  # CLI-INT-005
+    """execute_prompt() raises KeyboardInterrupt when _interrupted is True."""
+    def mock_communicate(timeout=None):
+        interface._interrupted = True  # simulates kill_current() firing during communicate()
+        return ("output", "")
+
+    mock_proc = make_mock_proc()
+    mock_proc.communicate.side_effect = mock_communicate
+
+    with patch("subprocess.Popen", return_value=mock_proc):
+        with pytest.raises(KeyboardInterrupt):
+            interface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert interface._interrupted is False  # cleared in finally
+
+
+def test_timeout_clears_interrupted_flag(interface):  # CLI-INT-006
+    """When TimeoutExpired is raised, _interrupted is False afterward."""
+    def mock_kill_proc_group(proc, sig):
+        if sig == _SIGKILL:
+            interface._interrupted = True  # simulates kill_current() during timeout teardown
+
+    mock_proc = make_mock_proc()
+    mock_proc.pid = 99999
+    mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+
+    with patch("subprocess.Popen", return_value=mock_proc), \
+         patch.object(ClaudeCodeInterface, "_kill_proc_group", side_effect=mock_kill_proc_group):
+        result = interface.execute_prompt(QueuedPrompt(content="task"))
+
+    assert result.success is False
+    assert "timed out" in result.error
+    assert interface._interrupted is False  # cleared in finally despite being True mid-timeout
+
+
+def test_close_is_idempotent(interface):  # CLI-INT-007
+    """close() is safe to call multiple times."""
+    interface.close()
+    interface.close()  # should not raise
+
+
+def test_atexit_cleanup_survives_exceptions(interface):  # CLI-INT-008
+    """_atexit_cleanup() does not raise even when kill_current() raises."""
+    interface.kill_current = MagicMock(side_effect=AttributeError("os is None"))
+    interface._atexit_cleanup()  # should not raise
+
+
+def test_base_exception_cleanup_kills_subprocess(interface):  # CLI-INT-009
+    """except BaseException cleanup kills the subprocess on KeyboardInterrupt."""
+    mock_proc = make_mock_proc()
+    mock_proc.communicate.side_effect = KeyboardInterrupt
+
+    with patch("subprocess.Popen", return_value=mock_proc), \
+         patch.object(ClaudeCodeInterface, "_kill_proc_group") as mock_kpg:
+        with pytest.raises(KeyboardInterrupt):
+            interface.execute_prompt(QueuedPrompt(content="task"))
+
+    mock_kpg.assert_called_once_with(mock_proc, _SIGKILL)
+    assert interface._current_process is None
+    assert interface._interrupted is False

--- a/tests/test_claude_interface.py
+++ b/tests/test_claude_interface.py
@@ -16,6 +16,8 @@ from claude_code_queue.claude_interface import (
     ClaudeCodeInterface,
     _RATE_LIMIT_MAX_RESET_HOURS,
     _RATE_LIMIT_SCAN_CHARS,
+    _NON_RETRYABLE_SCAN_CHARS,
+    _NON_RETRYABLE_PATTERNS,
 )
 from claude_code_queue.models import QueuedPrompt, RateLimitInfo, PromptStatus
 
@@ -654,3 +656,150 @@ def test_false_positive_not_detected(interface, fp_text):  # S11c
     assert result.is_rate_limited is False, (
         f"False positive triggered by:\n  {fp_text!r}"
     )
+
+
+# ===========================================================================
+# Non-Retryable Error Detection
+# ===========================================================================
+
+
+def test_detect_non_retryable_error_nested_session(interface):  # CLI-NR-001
+    """Nested-session stderr triggers is_non_retryable detection."""
+    stderr = (
+        "Error: Claude Code cannot be launched inside another Claude Code session.\n"
+        "Nested sessions share runtime resources and will crash all active sessions.\n"
+        "To bypass this check, unset the CLAUDECODE environment variable."
+    )
+    assert interface._detect_non_retryable_error(stderr) is True
+
+
+def test_detect_non_retryable_error_ordinary_failure(interface):  # CLI-NR-002
+    """Ordinary failure messages do not trigger non-retryable detection."""
+    assert interface._detect_non_retryable_error("Error: something went wrong") is False
+    assert interface._detect_non_retryable_error("") is False
+    assert interface._detect_non_retryable_error("rate limit exceeded") is False
+
+
+def test_detect_non_retryable_error_case_insensitive(interface):  # CLI-NR-003
+    """Non-retryable pattern matching is case-insensitive."""
+    assert interface._detect_non_retryable_error(
+        "CLAUDE CODE CANNOT BE LAUNCHED INSIDE ANOTHER CLAUDE CODE SESSION."
+    ) is True
+
+
+def test_execute_prompt_sets_is_non_retryable_on_nested_session_error(interface):  # CLI-NR-004
+    """ExecutionResult.is_non_retryable is True when subprocess stderr contains the nested-session message."""
+    nested_session_stderr = (
+        "Error: Claude Code cannot be launched inside another Claude Code session.\n"
+        "To bypass this check, unset the CLAUDECODE environment variable."
+    )
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr=nested_session_stderr
+        )
+        result = interface.execute_prompt(QueuedPrompt(content="test"))
+    assert result.is_non_retryable is True
+    assert result.success is False
+
+
+def test_execute_prompt_is_non_retryable_false_for_ordinary_failure(interface):  # CLI-NR-005
+    """ExecutionResult.is_non_retryable is False for retryable subprocess errors."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="some random error"
+        )
+        result = interface.execute_prompt(QueuedPrompt(content="test"))
+    assert result.is_non_retryable is False
+
+
+def test_detect_non_retryable_error_ignores_phrase_beyond_scan_window(interface):  # CLI-NR-006
+    """A non-retryable phrase that appears only AFTER _NON_RETRYABLE_SCAN_CHARS characters
+    must NOT trigger detection — same discipline as the S11b rate-limit scan-window guard.
+    """
+    prefix = "x" * _NON_RETRYABLE_SCAN_CHARS
+    assert interface._detect_non_retryable_error(
+        prefix + "\n" + _NON_RETRYABLE_PATTERNS[0]
+    ) is False
+
+
+def test_detect_non_retryable_error_fires_at_last_char_of_scan_window(interface):  # CLI-NR-007
+    """A pattern whose final character sits at index _NON_RETRYABLE_SCAN_CHARS - 1
+    (the last position inside the window) is still detected.
+
+    Validates the boundary is inclusive: stderr[:N] includes index N-1.
+    """
+    pattern = _NON_RETRYABLE_PATTERNS[0]
+    prefix = "x" * (_NON_RETRYABLE_SCAN_CHARS - len(pattern))
+    assert interface._detect_non_retryable_error(
+        prefix + pattern + "x" * 1000
+    ) is True
+
+
+# ===========================================================================
+# CLAUDECODE Environment Stripping
+# ===========================================================================
+
+
+def test_execute_prompt_strips_claudecode_from_env(interface, monkeypatch):  # CLI-ENV-001
+    """CLAUDECODE is removed from the subprocess environment."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        interface.execute_prompt(QueuedPrompt(content="test"))
+    _, kwargs = mock_run.call_args
+    assert "CLAUDECODE" not in kwargs["env"]
+
+
+def test_execute_prompt_preserves_other_env_vars(interface, monkeypatch):  # CLI-ENV-002
+    """Other environment variables (e.g. PATH, HOME) are passed through unchanged."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("MY_CUSTOM_VAR", "hello")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        interface.execute_prompt(QueuedPrompt(content="test"))
+    _, kwargs = mock_run.call_args
+    assert "MY_CUSTOM_VAR" in kwargs["env"]
+    assert kwargs["env"]["MY_CUSTOM_VAR"] == "hello"
+    assert "PATH" in kwargs["env"]
+
+
+def test_execute_prompt_env_strip_noop_when_claudecode_absent(interface, monkeypatch):  # CLI-ENV-003
+    """If CLAUDECODE is not set, the env passed to subprocess is otherwise intact."""
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        interface.execute_prompt(QueuedPrompt(content="test"))
+    _, kwargs = mock_run.call_args
+    assert "CLAUDECODE" not in kwargs["env"]
+    assert "PATH" in kwargs["env"]  # rest of env is intact
+
+
+def test_verify_claude_available_strips_claudecode_from_env(mocker, monkeypatch):  # CLI-ENV-004
+    """_verify_claude_available() strips CLAUDECODE from the --version subprocess."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="2.1.50 (Claude Code)", stderr="")
+        ClaudeCodeInterface(claude_command="claude", timeout=60)
+    _, kwargs = mock_run.call_args
+    assert "env" in kwargs
+    assert "CLAUDECODE" not in kwargs["env"]
+
+
+def test_test_connection_strips_claudecode_from_env(interface, monkeypatch):  # CLI-ENV-005
+    """test_connection() strips CLAUDECODE from the --help subprocess."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        interface.test_connection()
+    _, kwargs = mock_run.call_args
+    assert "CLAUDECODE" not in kwargs["env"]
+
+
+def test_get_available_commands_strips_claudecode_from_env(interface, monkeypatch):  # CLI-ENV-006
+    """get_available_commands() strips CLAUDECODE from the --help subprocess."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        interface.get_available_commands()
+    _, kwargs = mock_run.call_args
+    assert "CLAUDECODE" not in kwargs["env"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ Covers: argument parsing, global option forwarding, command dispatch,
 output format (text and JSON), bank sub-commands, prompt-box passthrough,
 and exit codes for every command.
 
-All tests mock ``QueueManager`` to avoid real storage / subprocess calls.
+Storage commands mock ``QueueStorage``; commands that invoke claude mock ``QueueManager``.
 Commands are exercised by patching ``sys.argv`` and calling ``main()``.
 """
 
@@ -146,91 +146,91 @@ class TestGlobalOptions:
 class TestAddCommand:
     def _run_add(self, *extra_args, success=True):
         with patch("sys.argv", ["claude-queue", "add", "hello world"] + list(extra_args)):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.add_prompt.return_value = success
-                mock_cls.return_value = mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage._save_single_prompt.return_value = success
+                mock_cls.return_value = storage
                 code = main()
-                return code, mgr
+                return code, storage
 
     def test_add_prompt_content(self):
-        _, mgr = self._run_add()
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add()
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.content == "hello world"
 
     def test_add_default_priority_zero(self):
-        _, mgr = self._run_add()
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add()
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.priority == 0
 
     def test_add_long_priority_flag(self):
-        _, mgr = self._run_add("--priority", "5")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("--priority", "5")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.priority == 5
 
     def test_add_short_priority_flag(self):
-        _, mgr = self._run_add("-p", "3")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("-p", "3")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.priority == 3
 
     def test_add_default_working_dir_dot(self):
-        _, mgr = self._run_add()
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add()
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.working_directory == "."
 
     def test_add_long_working_dir_flag(self):
-        _, mgr = self._run_add("--working-dir", "/some/path")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("--working-dir", "/some/path")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.working_directory == "/some/path"
 
     def test_add_short_working_dir_flag(self):
-        _, mgr = self._run_add("-d", "/some/path")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("-d", "/some/path")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.working_directory == "/some/path"
 
     def test_add_context_files_long_flag(self):
-        _, mgr = self._run_add("--context-files", "a.py", "b.py")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("--context-files", "a.py", "b.py")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.context_files == ["a.py", "b.py"]
 
     def test_add_context_files_short_flag(self):
-        _, mgr = self._run_add("-f", "a.py")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("-f", "a.py")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.context_files == ["a.py"]
 
     def test_add_default_context_files_empty(self):
-        _, mgr = self._run_add()
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add()
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.context_files == []
 
     def test_add_max_retries_long_flag(self):
-        _, mgr = self._run_add("--max-retries", "5")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("--max-retries", "5")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.max_retries == 5
 
     def test_add_max_retries_short_flag(self):
-        _, mgr = self._run_add("-r", "2")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("-r", "2")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.max_retries == 2
 
     def test_add_default_max_retries_three(self):
-        _, mgr = self._run_add()
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add()
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.max_retries == 3
 
     def test_add_estimated_tokens_long_flag(self):
-        _, mgr = self._run_add("--estimated-tokens", "1500")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("--estimated-tokens", "1500")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.estimated_tokens == 1500
 
     def test_add_estimated_tokens_short_flag(self):
-        _, mgr = self._run_add("-t", "1000")
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add("-t", "1000")
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.estimated_tokens == 1000
 
     def test_add_default_estimated_tokens_none(self):
-        _, mgr = self._run_add()
-        prompt = mgr.add_prompt.call_args[0][0]
+        _, storage = self._run_add()
+        prompt = storage._save_single_prompt.call_args[0][0]
         assert prompt.estimated_tokens is None
 
     def test_add_returns_zero_on_success(self):
@@ -241,6 +241,15 @@ class TestAddCommand:
         code, _ = self._run_add(success=False)
         assert code == 1
 
+    def test_add_passes_storage_dir_to_storage(self):
+        with patch("sys.argv", ["claude-queue", "--storage-dir", "/custom/path", "add", "hello"]):
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                mock_cls.return_value._save_single_prompt.return_value = True
+                main()
+                mock_cls.assert_called_once()  # guard: fails clearly if storage was never constructed
+                _, kwargs = mock_cls.call_args
+                assert kwargs["storage_dir"] == "/custom/path"
+
 
 # ===========================================================================
 # `template` Command
@@ -249,30 +258,30 @@ class TestAddCommand:
 class TestTemplateCommand:
     def _run_template(self, *extra_args, path="/some/path/my-template.md"):
         with patch("sys.argv", ["claude-queue", "template", "my-template"] + list(extra_args)):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.create_prompt_template.return_value = path
-                mock_cls.return_value = mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.create_prompt_template.return_value = path
+                mock_cls.return_value = storage
                 code = main()
-                return code, mgr
+                return code, storage
 
     def test_template_calls_create_with_filename(self):
-        _, mgr = self._run_template()
-        mgr.create_prompt_template.assert_called_once_with("my-template", 0)
+        _, storage = self._run_template()
+        storage.create_prompt_template.assert_called_once_with("my-template", 0)
 
     def test_template_default_priority_zero(self):
-        _, mgr = self._run_template()
-        _, priority = mgr.create_prompt_template.call_args[0]
+        _, storage = self._run_template()
+        _, priority = storage.create_prompt_template.call_args[0]
         assert priority == 0
 
     def test_template_long_priority_flag(self):
-        _, mgr = self._run_template("--priority", "2")
-        _, priority = mgr.create_prompt_template.call_args[0]
+        _, storage = self._run_template("--priority", "2")
+        _, priority = storage.create_prompt_template.call_args[0]
         assert priority == 2
 
     def test_template_short_priority_flag(self):
-        _, mgr = self._run_template("-p", "1")
-        _, priority = mgr.create_prompt_template.call_args[0]
+        _, storage = self._run_template("-p", "1")
+        _, priority = storage.create_prompt_template.call_args[0]
         assert priority == 1
 
     def test_template_prints_created_path(self, capsys):
@@ -299,10 +308,10 @@ class TestStatusCommand:
         if state is None:
             state = _make_state()
         with patch("sys.argv", ["claude-queue", "status"] + list(extra_args)):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.get_status.return_value = state
-                mock_cls.return_value = mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.load_queue_state.return_value = state
+                mock_cls.return_value = storage
                 code = main()
                 return code
 
@@ -397,17 +406,30 @@ class TestStatusCommand:
 
 class TestCancelCommand:
     def _run_cancel(self, prompt_id, success=True):
-        with patch("sys.argv", ["claude-queue", "cancel", prompt_id]):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.remove_prompt.return_value = success
-                mock_cls.return_value = mgr
-                code = main()
-                return code, mgr
+        # Build a real QueueState containing the target prompt so that
+        # state.get_prompt(prompt_id) returns it instead of None.
+        target_prompt = QueuedPrompt(id=prompt_id, content="some content")
+        state = _make_state(prompts=[target_prompt])
 
-    def test_cancel_calls_remove_prompt_with_id(self):
-        _, mgr = self._run_cancel("abc123")
-        mgr.remove_prompt.assert_called_once_with("abc123")
+        with patch("sys.argv", ["claude-queue", "cancel", prompt_id]):
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.load_queue_state.return_value = state
+                # Note: call_args captures a reference to the QueuedPrompt dataclass,
+                # not a snapshot. Assertions on call_args[0][0] see the object's state
+                # at assertion time. cmd_cancel does not modify the prompt after calling
+                # _save_single_prompt, so this is safe.
+                storage._save_single_prompt.return_value = success
+                mock_cls.return_value = storage
+                code = main()
+                return code, storage
+
+    def test_cancel_marks_prompt_cancelled_and_saves(self):
+        _, storage = self._run_cancel("abc123")
+        storage._save_single_prompt.assert_called_once()
+        saved_prompt = storage._save_single_prompt.call_args[0][0]
+        assert saved_prompt.id == "abc123"
+        assert saved_prompt.status == PromptStatus.CANCELLED
 
     def test_cancel_returns_zero_on_success(self):
         code, _ = self._run_cancel("abc123", success=True)
@@ -415,6 +437,29 @@ class TestCancelCommand:
 
     def test_cancel_returns_one_on_failure(self):
         code, _ = self._run_cancel("abc123", success=False)
+        assert code == 1
+
+    def test_cancel_prompt_not_found_returns_one(self):
+        state = _make_state(prompts=[])  # target ID absent from queue
+        with patch("sys.argv", ["claude-queue", "cancel", "abc123"]):
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.load_queue_state.return_value = state
+                mock_cls.return_value = storage
+                code = main()
+        assert code == 1
+
+    def test_cancel_executing_prompt_returns_one(self):
+        target_prompt = QueuedPrompt(
+            id="abc123", content="x", status=PromptStatus.EXECUTING
+        )
+        state = _make_state(prompts=[target_prompt])
+        with patch("sys.argv", ["claude-queue", "cancel", "abc123"]):
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.load_queue_state.return_value = state
+                mock_cls.return_value = storage
+                code = main()
         assert code == 1
 
 
@@ -436,10 +481,10 @@ class TestListCommand:
         p = prompts if prompts is not None else self._ALL_PROMPTS
         state = _make_state(prompts=p)
         with patch("sys.argv", ["claude-queue", "list"] + list(extra_args)):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.get_status.return_value = state
-                mock_cls.return_value = mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.load_queue_state.return_value = state
+                mock_cls.return_value = storage
                 code = main()
                 return code
 
@@ -488,7 +533,7 @@ class TestListCommand:
     def test_list_invalid_status_is_argparse_error(self):
         with pytest.raises(SystemExit) as exc_info:
             with patch("sys.argv", ["claude-queue", "list", "--status", "invalid_value"]):
-                with patch("claude_code_queue.cli.QueueManager"):
+                with patch("claude_code_queue.cli.QueueStorage"):
                     main()
         assert exc_info.value.code != 0
 
@@ -576,30 +621,30 @@ class TestBankSaveCommand:
 
     def _run_bank_save(self, *extra_args):
         with patch("sys.argv", ["claude-queue", "bank", "save", "my-template"] + list(extra_args)):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.save_prompt_to_bank.return_value = self._BANK_PATH
-                mock_cls.return_value = mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.save_prompt_to_bank.return_value = self._BANK_PATH
+                mock_cls.return_value = storage
                 code = main()
-                return code, mgr
+                return code, storage
 
     def test_bank_save_calls_save_prompt_to_bank(self):
-        _, mgr = self._run_bank_save()
-        mgr.save_prompt_to_bank.assert_called_once_with("my-template", 0)
+        _, storage = self._run_bank_save()
+        storage.save_prompt_to_bank.assert_called_once_with("my-template", 0)
 
     def test_bank_save_default_priority_zero(self):
-        _, mgr = self._run_bank_save()
-        _, priority = mgr.save_prompt_to_bank.call_args[0]
+        _, storage = self._run_bank_save()
+        _, priority = storage.save_prompt_to_bank.call_args[0]
         assert priority == 0
 
     def test_bank_save_long_priority_flag(self):
-        _, mgr = self._run_bank_save("--priority", "3")
-        _, priority = mgr.save_prompt_to_bank.call_args[0]
+        _, storage = self._run_bank_save("--priority", "3")
+        _, priority = storage.save_prompt_to_bank.call_args[0]
         assert priority == 3
 
     def test_bank_save_short_priority_flag(self):
-        _, mgr = self._run_bank_save("-p", "2")
-        _, priority = mgr.save_prompt_to_bank.call_args[0]
+        _, storage = self._run_bank_save("-p", "2")
+        _, priority = storage.save_prompt_to_bank.call_args[0]
         assert priority == 2
 
     def test_bank_save_prints_path(self, capsys):
@@ -624,10 +669,10 @@ class TestBankListCommand:
         if templates is None:
             templates = [_make_template()]
         with patch("sys.argv", ["claude-queue", "bank", "list"] + list(extra_args)):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.list_bank_templates.return_value = templates
-                mock_cls.return_value = mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.list_bank_templates.return_value = templates
+                mock_cls.return_value = storage
                 code = main()
                 return code
 
@@ -701,22 +746,36 @@ class TestBankListCommand:
 class TestBankUseCommand:
     def _run_bank_use(self, success=True):
         with patch("sys.argv", ["claude-queue", "bank", "use", "my-template"]):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.use_bank_template.return_value = success
-                mock_cls.return_value = mgr
-                return main(), mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                # use_bank_template must return a real QueuedPrompt so the CLI
+                # doesn't short-circuit with "Template not found".
+                # For success=False we still return a prompt but
+                # _save_single_prompt returns False.
+                storage.use_bank_template.return_value = QueuedPrompt(content="tmpl")
+                storage._save_single_prompt.return_value = success
+                mock_cls.return_value = storage
+                return main(), storage
 
     def test_bank_use_calls_use_bank_template(self):
-        _, mgr = self._run_bank_use()
-        mgr.use_bank_template.assert_called_once_with("my-template")
+        _, storage = self._run_bank_use()
+        storage.use_bank_template.assert_called_once_with("my-template")
 
     def test_bank_use_returns_zero_on_success(self):
         code, _ = self._run_bank_use(success=True)
         assert code == 0
 
-    def test_bank_use_returns_one_on_failure(self):
+    def test_bank_use_returns_one_when_save_fails(self):
         code, _ = self._run_bank_use(success=False)
+        assert code == 1
+
+    def test_bank_use_returns_one_when_template_not_found(self):
+        with patch("sys.argv", ["claude-queue", "bank", "use", "my-template"]):
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.use_bank_template.return_value = None  # template absent
+                mock_cls.return_value = storage
+                code = main()
         assert code == 1
 
 
@@ -727,15 +786,15 @@ class TestBankUseCommand:
 class TestBankDeleteCommand:
     def _run_bank_delete(self, success=True):
         with patch("sys.argv", ["claude-queue", "bank", "delete", "my-template"]):
-            with patch("claude_code_queue.cli.QueueManager") as mock_cls:
-                mgr = MagicMock()
-                mgr.delete_bank_template.return_value = success
-                mock_cls.return_value = mgr
-                return main(), mgr
+            with patch("claude_code_queue.cli.QueueStorage") as mock_cls:
+                storage = MagicMock()
+                storage.delete_bank_template.return_value = success
+                mock_cls.return_value = storage
+                return main(), storage
 
     def test_bank_delete_calls_delete_bank_template(self):
-        _, mgr = self._run_bank_delete()
-        mgr.delete_bank_template.assert_called_once_with("my-template")
+        _, storage = self._run_bank_delete()
+        storage.delete_bank_template.assert_called_once_with("my-template")
 
     def test_bank_delete_returns_zero_on_success(self):
         code, _ = self._run_bank_delete(success=True)
@@ -751,6 +810,11 @@ class TestBankDeleteCommand:
 # ===========================================================================
 
 class TestBankNoSubcommand:
+    """
+    cmd_bank returns 1 before constructing any storage when no subcommand is given.
+    The QueueManager patch is a no-op guard against accidental instantiation.
+    """
+
     def _run_bank_no_subcommand(self):
         with patch("sys.argv", ["claude-queue", "bank"]):
             with patch("claude_code_queue.cli.QueueManager") as mock_cls:
@@ -778,8 +842,8 @@ class TestBankNoSubcommand:
 
 class TestPromptBoxCommand:
     """
-    cmd_prompt_box does not use the manager, but QueueManager is still
-    instantiated in main() before the command dispatch, so we always mock it.
+    cmd_prompt_box does not use QueueManager or QueueStorage. The patch is
+    retained as a no-op guard against accidental QueueManager instantiation.
     shutil is imported inside the function, so we patch shutil.which directly.
     """
 

--- a/tests/test_fault_tolerance.py
+++ b/tests/test_fault_tolerance.py
@@ -1,0 +1,1833 @@
+"""
+Fault tolerance tests — file system errors, subprocess death, crash recovery,
+network failures, authentication failures, and complex failure scenarios.
+
+Label scheme: FT-001 through FT-085.
+
+Sections:
+  FT-001..013  File system write errors         (class TestWriteErrors)
+  FT-014..020  File system read errors          (class TestReadErrors)
+  FT-021..023  Disk-full (ENOSPC)               (class TestDiskFull)
+  FT-024..028  TOCTOU / deletion races          (class TestTOCTOU)
+  FT-029..030  Init failures                    (class TestInitErrors)
+  FT-031..036  Manager storage errors           (class TestManagerErrors)
+  FT-037..043  Known bugs (xfail)               (class TestKnownBugs)
+  FT-044..056  Subprocess death                 (module-level)
+  FT-057..066  SIGKILL / crash recovery         (class TestSIGKILLRecovery)
+  FT-067..074  Network failures                 (module-level)
+  FT-075..083  Authentication failures          (module-level)
+  FT-084..085  Complex failure scenarios        (module-level)
+"""
+
+import builtins
+import errno
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_code_queue.claude_interface import ClaudeCodeInterface
+from claude_code_queue.models import (
+    ExecutionResult,
+    PromptStatus,
+    QueuedPrompt,
+    QueueState,
+    RateLimitInfo,
+)
+from claude_code_queue.queue_manager import QueueManager
+from claude_code_queue.storage import MarkdownPromptParser, QueueStorage
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+ENOSPC_ERROR = OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+
+VALID_FRONTMATTER = (
+    "---\n"
+    "priority: 0\n"
+    "working_directory: .\n"
+    "max_retries: 3\n"
+    "status: queued\n"
+    "retry_count: 0\n"
+    "created_at: 2025-01-01T00:00:00\n"
+    "---\n\n"
+    "task"
+)
+
+_EXEC_FRONTMATTER = (
+    "---\n"
+    "priority: 0\n"
+    "working_directory: .\n"
+    "max_retries: 3\n"
+    "status: executing\n"
+    "retry_count: {retry_count}\n"
+    "created_at: 2025-01-01T00:00:00\n"
+    "---\n\n"
+    "{content}"
+)
+
+
+def _write_executing_file(queue_dir, prompt_id, slug, content="task", retry_count=0):
+    path = queue_dir / f"{prompt_id}-{slug}.executing.md"
+    path.write_text(
+        _EXEC_FRONTMATTER.format(retry_count=retry_count, content=content)
+    )
+    return path
+
+
+def _fail_result(error: str = "exit 1") -> ExecutionResult:
+    return ExecutionResult(
+        success=False,
+        output="",
+        error=error,
+        execution_time=0.1,
+        rate_limit_info=RateLimitInfo(is_rate_limited=False),
+    )
+
+
+def _timeout_result() -> ExecutionResult:
+    return ExecutionResult(
+        success=False,
+        output="",
+        error="Execution timed out after 3600 seconds",
+        execution_time=3600.1,
+        rate_limit_info=RateLimitInfo(is_rate_limited=False),
+    )
+
+
+def _network_fail_result() -> ExecutionResult:
+    return ExecutionResult(
+        success=False,
+        output="",
+        error="curl: (6) Could not resolve host: api.anthropic.com",
+        execution_time=30.0,
+        rate_limit_info=RateLimitInfo(is_rate_limited=False),
+    )
+
+
+def _auth_fail_result(error: str = "Error: Not authenticated. Please run 'claude login'.") -> ExecutionResult:
+    return ExecutionResult(
+        success=False,
+        output="",
+        error=error,
+        execution_time=0.3,
+        rate_limit_info=RateLimitInfo(is_rate_limited=False),
+    )
+
+
+def _success_result(output: str = "done") -> ExecutionResult:
+    return ExecutionResult(
+        success=True,
+        output=output,
+        error="",
+        execution_time=1.0,
+        rate_limit_info=RateLimitInfo(is_rate_limited=False),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level fixtures (used by subprocess death, network, auth, scenario tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def iface():
+    """ClaudeCodeInterface with __init__ bypassed via __new__."""
+    obj = ClaudeCodeInterface.__new__(ClaudeCodeInterface)
+    obj.claude_command = "claude"
+    obj.timeout = 3600
+    obj.skip_permissions = True
+    return obj
+
+
+@pytest.fixture
+def mock_iface():
+    """Mocked ClaudeCodeInterface."""
+    m = MagicMock(spec=ClaudeCodeInterface)
+    m.test_connection.return_value = (True, "OK")
+    return m
+
+
+@pytest.fixture
+def mgr(tmp_path, mock_iface):
+    """QueueManager with real storage and mocked claude interface (running=False)."""
+    m = QueueManager.__new__(QueueManager)
+    m.storage = QueueStorage(str(tmp_path))
+    m.claude_interface = mock_iface
+    m.check_interval = 30
+    m.running = False
+    m.state = None
+    return m
+
+
+# ===========================================================================
+# File System Write Errors
+# ===========================================================================
+
+
+class TestWriteErrors:
+    """FT-001..013: write-permission / write-error failures."""
+
+    def test_write_prompt_file_returns_false_on_permission_error(self, tmp_path):  # FT-001
+        """write_prompt_file returns False when open() raises PermissionError."""
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task")
+        file_path = storage.queue_dir / "abc12345-task.md"
+
+        with patch("builtins.open", side_effect=PermissionError("read-only")):
+            result = storage.parser.write_prompt_file(prompt, file_path)
+
+        assert result is False
+
+    def test_save_queue_state_returns_false_on_json_write_error(self, tmp_path):  # FT-002
+        """save_queue_state returns False when the state JSON cannot be opened."""
+        storage = QueueStorage(str(tmp_path))
+        state = QueueState()
+
+        real_open = builtins.open
+
+        def selective_open(path, *args, **kwargs):
+            if "queue-state.json" in str(path) and args and "w" in args[0]:
+                raise PermissionError("read-only")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=selective_open):
+            result = storage.save_queue_state(state)
+
+        assert result is False
+
+    def test_in_memory_state_unchanged_when_save_fails(self, tmp_path):  # FT-003
+        """save_queue_state never mutates the state object it receives."""
+        storage = QueueStorage(str(tmp_path))
+        state = QueueState()
+        state.total_processed = 7
+        state.failed_count = 2
+        prompt = QueuedPrompt(id="abc12345", content="task")
+        state.add_prompt(prompt)
+
+        with patch("builtins.open", side_effect=PermissionError("read-only")):
+            storage.save_queue_state(state)
+
+        assert state.total_processed == 7
+        assert state.failed_count == 2
+        assert len(state.prompts) == 1
+        assert state.prompts[0].id == "abc12345"
+
+    def test_save_single_prompt_catches_unexpected_write_exception(self, tmp_path):  # FT-004
+        """_save_single_prompt outer except catches RuntimeError from write_prompt_file."""
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task")
+
+        with patch.object(
+            storage.parser,
+            "write_prompt_file",
+            side_effect=RuntimeError("unexpected internal error"),
+        ):
+            result = storage._save_single_prompt(prompt)
+
+        assert result is False
+
+    def test_save_single_prompt_propagates_false_from_write_prompt_file(self, tmp_path):  # FT-005
+        """_save_single_prompt returns False when write_prompt_file returns False."""
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task")
+
+        with patch.object(storage.parser, "write_prompt_file", return_value=False):
+            result = storage._save_single_prompt(prompt)
+
+        assert result is False
+
+    def test_executing_save_failure_loses_queued_file(self, tmp_path):  # FT-006
+        """When EXECUTING write fails, _remove_prompt_files has already deleted the
+        QUEUED file — the prompt vanishes from all directories (documents data-loss bug).
+        """
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(
+            id="abc12345", content="task", status=PromptStatus.EXECUTING
+        )
+
+        queue_file = storage.queue_dir / "abc12345-task.md"
+        queue_file.write_text(VALID_FRONTMATTER)
+
+        with patch.object(storage.parser, "write_prompt_file", return_value=False):
+            storage._save_single_prompt(prompt)
+
+        assert not queue_file.exists(), (
+            "QUEUED file deleted even when EXECUTING write failed — data loss"
+        )
+        assert list(storage.queue_dir.glob("abc12345*.executing.md")) == [], (
+            "No EXECUTING file exists after write failure"
+        )
+
+    def test_completed_prompt_not_lost_when_write_fails(self, tmp_path):  # FT-007
+        """When COMPLETED write fails the queue file must survive (write-then-delete order).
+        This assertion FAILS against current code — documents the delete-before-write bug.
+        """
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task", status=PromptStatus.QUEUED)
+        queue_file = storage.queue_dir / "abc12345-task.md"
+        queue_file.write_text(VALID_FRONTMATTER)
+
+        prompt.status = PromptStatus.COMPLETED
+        with patch.object(storage.parser, "write_prompt_file", return_value=False):
+            storage._save_single_prompt(prompt)
+
+        surviving = (
+            list(storage.queue_dir.glob("abc12345*.md"))
+            + list(storage.completed_dir.glob("abc12345*.md"))
+        )
+        assert len(surviving) > 0, (
+            "Prompt must not vanish from all directories when completed write fails"
+        )
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            PermissionError("read-only"),
+            OSError(errno.ENOSPC, os.strerror(errno.ENOSPC)),
+        ],
+        ids=["permission_error", "enospc"],
+    )
+    def test_create_prompt_template_raises_on_write_error(self, tmp_path, exc):  # FT-008
+        """create_prompt_template has no try/except — write errors propagate."""
+        storage = QueueStorage(str(tmp_path))
+        with patch("builtins.open", side_effect=exc):
+            with pytest.raises(OSError):
+                storage.create_prompt_template("my-task")
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            PermissionError("read-only"),
+            OSError(errno.ENOSPC, os.strerror(errno.ENOSPC)),
+        ],
+        ids=["permission_error", "enospc"],
+    )
+    def test_save_prompt_to_bank_raises_on_write_error(self, tmp_path, exc):  # FT-009
+        """save_prompt_to_bank has no try/except — write errors propagate."""
+        storage = QueueStorage(str(tmp_path))
+        with patch("builtins.open", side_effect=exc):
+            with pytest.raises(OSError):
+                storage.save_prompt_to_bank("my-template")
+
+    def test_delete_bank_template_returns_false_when_unlink_fails(self, tmp_path):  # FT-010
+        """delete_bank_template catches unlink errors and returns False."""
+        storage = QueueStorage(str(tmp_path))
+        storage.save_prompt_to_bank("temp")
+
+        with patch.object(Path, "unlink", side_effect=PermissionError("locked")):
+            result = storage.delete_bank_template("temp")
+
+        assert result is False
+
+    def test_remove_prompt_files_does_not_raise_when_unlink_fails(self, tmp_path):  # FT-011
+        """_remove_prompt_files swallows unlink errors and returns normally."""
+        storage = QueueStorage(str(tmp_path))
+        prompt_id = "abc12345"
+        (storage.queue_dir / f"{prompt_id}-task.md").write_text("content")
+        (storage.queue_dir / f"{prompt_id}-task.executing.md").write_text("content")
+
+        with patch.object(Path, "unlink", side_effect=PermissionError("locked")):
+            storage._remove_prompt_files(prompt_id, storage.queue_dir)
+
+    def test_write_prompt_file_returns_false_when_yaml_dump_raises(self, tmp_path):  # FT-012
+        """If yaml.dump raises mid-write, write_prompt_file must return False."""
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task")
+        prompt.add_log("Step 1 done")
+        file_path = storage.queue_dir / "abc12345-task.md"
+
+        with patch(
+            "claude_code_queue.storage.yaml.dump",
+            side_effect=OSError(errno.ENOSPC, "No space left on device"),
+        ):
+            result = storage.parser.write_prompt_file(prompt, file_path)
+
+        assert result is False
+
+    def test_add_prompt_from_markdown_raises_on_move_error(self, tmp_path):  # FT-013
+        """add_prompt_from_markdown propagates shutil.move errors unchecked."""
+        storage = QueueStorage(str(tmp_path))
+        external_file = tmp_path / "my-prompt.md"
+        external_file.write_text(
+            "---\npriority: 0\nworking_directory: .\nmax_retries: 3\n---\n\nDo something."
+        )
+
+        with patch(
+            "claude_code_queue.storage.shutil.move",
+            side_effect=OSError("cross-device link"),
+        ):
+            with pytest.raises(OSError):
+                storage.add_prompt_from_markdown(external_file)
+
+
+# ===========================================================================
+# File System Read Errors
+# ===========================================================================
+
+
+class TestReadErrors:
+    """FT-014..020: read-permission / read-error failures."""
+
+    def test_parse_prompt_file_returns_none_on_permission_error(self, tmp_path):  # FT-014
+        """parse_prompt_file returns None when open() raises PermissionError."""
+        storage = QueueStorage(str(tmp_path))
+        file_path = storage.queue_dir / "abc12345-task.md"
+        file_path.write_text("---\n---\n\ntask")
+
+        with patch("builtins.open", side_effect=PermissionError("no permission")):
+            result = storage.parser.parse_prompt_file(file_path)
+
+        assert result is None
+
+    def test_load_queue_state_skips_unreadable_prompt_file(self, tmp_path):  # FT-015
+        """One unreadable prompt file is skipped; others load correctly."""
+        storage = QueueStorage(str(tmp_path))
+        (storage.queue_dir / "abc12345-task-one.md").write_text(VALID_FRONTMATTER)
+        (storage.queue_dir / "def67890-task-two.md").write_text(
+            VALID_FRONTMATTER.replace("task", "task two")
+        )
+
+        real_open = builtins.open
+
+        def selective_open(path, *args, **kwargs):
+            if "abc12345" in str(path):
+                raise PermissionError("no permission")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=selective_open):
+            state = storage.load_queue_state()
+
+        loaded_ids = {p.id for p in state.prompts}
+        assert "abc12345" not in loaded_ids
+        assert "def67890" in loaded_ids
+        assert len(state.prompts) == 1
+
+    def test_load_queue_state_raises_when_load_prompts_raises(self, tmp_path):  # FT-016
+        """load_queue_state propagates exceptions from _load_prompts_from_files."""
+        storage = QueueStorage(str(tmp_path))
+
+        with patch.object(
+            storage,
+            "_load_prompts_from_files",
+            side_effect=PermissionError("queue dir not readable"),
+        ):
+            with pytest.raises(PermissionError):
+                storage.load_queue_state()
+
+    def test_load_queue_state_falls_back_when_state_json_unreadable(self, tmp_path):  # FT-017
+        """Unreadable queue-state.json causes counters to fall back to zero."""
+        storage = QueueStorage(str(tmp_path))
+        state = QueueState()
+        state.total_processed = 10
+        storage.save_queue_state(state)
+        assert storage.state_file.exists()
+
+        real_open = builtins.open
+
+        def selective_open(path, *args, **kwargs):
+            if "queue-state.json" in str(path) and args and "r" in args[0]:
+                raise PermissionError("no permission")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=selective_open):
+            loaded = storage.load_queue_state()
+
+        assert loaded.total_processed == 0
+        assert loaded.failed_count == 0
+
+    def test_list_bank_templates_skips_unreadable_files(self, tmp_path):  # FT-018
+        """list_bank_templates skips unreadable files and returns the rest."""
+        storage = QueueStorage(str(tmp_path))
+        storage.save_prompt_to_bank("alpha")
+        storage.save_prompt_to_bank("beta")
+
+        real_open = builtins.open
+
+        def selective_open(path, *args, **kwargs):
+            if "alpha" in str(path):
+                raise PermissionError("no permission")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=selective_open):
+            templates = storage.list_bank_templates()
+
+        assert len(templates) == 1
+        assert templates[0]["name"] == "beta"
+
+    def test_use_bank_template_returns_none_when_file_unreadable(self, tmp_path):  # FT-019
+        """use_bank_template returns None when the bank file exists but is unreadable."""
+        storage = QueueStorage(str(tmp_path))
+        storage.save_prompt_to_bank("daily")
+
+        with patch("builtins.open", side_effect=PermissionError("no permission")):
+            result = storage.use_bank_template("daily")
+
+        assert result is None
+
+    def test_add_prompt_from_markdown_returns_none_when_unreadable(self, tmp_path):  # FT-020
+        """add_prompt_from_markdown returns None when the source file is unreadable."""
+        storage = QueueStorage(str(tmp_path))
+        external_file = tmp_path / "my-prompt.md"
+        external_file.write_text("---\n---\n\nDo something.")
+
+        with patch("builtins.open", side_effect=PermissionError("no permission")):
+            result = storage.add_prompt_from_markdown(external_file)
+
+        assert result is None
+        assert external_file.exists()
+
+
+# ===========================================================================
+# Disk-Full (ENOSPC) Failures
+# ===========================================================================
+
+
+class TestDiskFull:
+    """FT-021..023: ENOSPC failures (unique cases)."""
+
+    def test_write_prompt_file_returns_false_on_enospc(self, tmp_path):  # FT-021
+        """write_prompt_file returns False on ENOSPC from open()."""
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task")
+        file_path = storage.queue_dir / "abc12345-task.md"
+
+        with patch(
+            "builtins.open",
+            side_effect=OSError(errno.ENOSPC, os.strerror(errno.ENOSPC)),
+        ):
+            result = storage.parser.write_prompt_file(prompt, file_path)
+
+        assert result is False
+
+    def test_save_queue_state_returns_true_despite_prompt_write_failures(self, tmp_path):  # FT-022
+        """Silent partial-failure bug: save_queue_state returns True even when every
+        prompt write failed (documents the false-success bug).
+        """
+        storage = QueueStorage(str(tmp_path))
+        state = QueueState()
+        state.add_prompt(QueuedPrompt(id="abc12345", content="task"))
+
+        with patch.object(storage.parser, "write_prompt_file", return_value=False):
+            result = storage.save_queue_state(state)
+
+        assert result is True
+        assert list(storage.queue_dir.glob("*.md")) == []
+
+    def test_save_queue_state_returns_false_on_enospc_for_state_json(self, tmp_path):  # FT-023
+        """save_queue_state returns False when queue-state.json write hits ENOSPC."""
+        storage = QueueStorage(str(tmp_path))
+        state = QueueState()
+
+        real_open = builtins.open
+
+        def selective_open(path, *args, **kwargs):
+            if "queue-state.json" in str(path) and args and "w" in args[0]:
+                raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=selective_open):
+            result = storage.save_queue_state(state)
+
+        assert result is False
+
+
+# ===========================================================================
+# TOCTOU / Deletion-Between-Operations
+# ===========================================================================
+
+
+class TestTOCTOU:
+    """FT-024..028: time-of-check/time-of-use races."""
+
+    def test_file_deleted_between_glob_and_parse_does_not_crash(self, tmp_path):  # FT-024
+        """File deleted between glob and parse is silently skipped."""
+        storage = QueueStorage(str(tmp_path))
+        (storage.queue_dir / "abc12345-task.md").write_text(VALID_FRONTMATTER)
+
+        original_parse = storage.parser.__class__.parse_prompt_file
+
+        def delete_then_parse(path):
+            path.unlink(missing_ok=True)
+            return original_parse(path)
+
+        with patch.object(
+            storage.parser, "parse_prompt_file", side_effect=delete_then_parse
+        ):
+            state = storage.load_queue_state()
+
+        assert len(state.prompts) == 0
+
+    def test_remove_prompt_files_handles_file_not_found_from_unlink(self, tmp_path):  # FT-025
+        """_remove_prompt_files swallows FileNotFoundError from unlink."""
+        storage = QueueStorage(str(tmp_path))
+        (storage.queue_dir / "abc12345-task.md").write_text("content")
+
+        with patch.object(
+            Path, "unlink", side_effect=FileNotFoundError("already deleted")
+        ):
+            storage._remove_prompt_files("abc12345", storage.queue_dir)
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            PromptStatus.COMPLETED,
+            PromptStatus.FAILED,
+            PromptStatus.CANCELLED,
+        ],
+    )
+    def test_save_single_prompt_write_failure_cross_dir_preserves_queue_file(
+        self, tmp_path, status
+    ):  # FT-026 (updated for FT-007 fix)
+        """Write-then-delete for cross-directory transitions: if the destination
+        write fails, the source queue file must survive.  FT-007 fix changed the
+        order from delete-before-write to write-then-conditional-delete.
+        """
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task", status=PromptStatus.QUEUED)
+        queue_file = storage.queue_dir / "abc12345-task.md"
+        queue_file.write_text(VALID_FRONTMATTER)
+
+        prompt.status = status
+        with patch.object(storage.parser, "write_prompt_file", return_value=False):
+            storage._save_single_prompt(prompt)
+
+        surviving_queue_files = list(storage.queue_dir.glob("abc12345-*.md"))
+        assert len(surviving_queue_files) == 1, (
+            f"Queue file lost on write failure for status={status.value} "
+            f"(FT-007: write-then-delete must preserve source on write failure)"
+        )
+
+    def test_save_single_prompt_executing_write_failure_loses_file(self, tmp_path):  # FT-026b
+        """Same-directory transition (EXECUTING) still uses delete-before-write:
+        a write failure leaves the prompt in no directory.  This is an accepted
+        trade-off; crash-recovery via load_queue_state handles it.
+        """
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task", status=PromptStatus.QUEUED)
+        queue_file = storage.queue_dir / "abc12345-task.md"
+        queue_file.write_text(VALID_FRONTMATTER)
+
+        prompt.status = PromptStatus.EXECUTING
+        with patch.object(storage.parser, "write_prompt_file", return_value=False):
+            storage._save_single_prompt(prompt)
+
+        all_prompt_files = (
+            list(storage.queue_dir.glob("abc12345-*.md"))
+            + list(storage.completed_dir.glob("abc12345-*.md"))
+            + list(storage.failed_dir.glob("abc12345-*.md"))
+        )
+        assert len(all_prompt_files) == 0, (
+            "EXECUTING same-dir transition: file expected to be gone after write failure"
+        )
+
+    def test_stat_failure_in_parse_prompt_file_returns_none(self, tmp_path):  # FT-027
+        """parse_prompt_file returns None when stat() raises after a successful open.
+
+        Uses a file without created_at so the fallback stat() path is exercised.
+        """
+        storage = QueueStorage(str(tmp_path))
+        file_path = storage.queue_dir / "abc12345-task.md"
+        file_path.write_text(
+            "---\n"
+            "priority: 0\n"
+            "working_directory: .\n"
+            "max_retries: 3\n"
+            "status: queued\n"
+            "retry_count: 0\n"
+            "---\n\n"
+            "task"
+        )
+
+        with patch.object(
+            Path, "stat", side_effect=FileNotFoundError("file gone after open")
+        ):
+            result = storage.parser.parse_prompt_file(file_path)
+
+        assert result is None
+
+    def test_list_bank_templates_stat_failure_skips_file(self, tmp_path):  # FT-028
+        """list_bank_templates catches per-file stat() errors and continues."""
+        storage = QueueStorage(str(tmp_path))
+        storage.save_prompt_to_bank("alpha")
+        storage.save_prompt_to_bank("beta")
+
+        original_stat = Path.stat
+
+        def stat_side_effect(self_path):
+            if self_path.name == "alpha.md":
+                raise FileNotFoundError("file gone")
+            return original_stat(self_path)
+
+        with patch.object(Path, "stat", stat_side_effect):
+            templates = storage.list_bank_templates()
+
+        assert len(templates) == 1
+
+
+# ===========================================================================
+# Init Failures
+# ===========================================================================
+
+
+class TestInitErrors:
+    """FT-029..030: QueueStorage initialisation failures."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            PermissionError("parent dir not writable"),
+            OSError(errno.ENOSPC, os.strerror(errno.ENOSPC)),
+        ],
+        ids=["permission_error", "enospc"],
+    )
+    def test_queue_storage_init_propagates_mkdir_error(self, tmp_path, exc):  # FT-029
+        """QueueStorage.__init__ propagates mkdir errors (no try/except)."""
+        with patch.object(Path, "mkdir", side_effect=exc):
+            with pytest.raises(OSError):
+                QueueStorage(str(tmp_path))
+
+    def test_queue_storage_init_succeeds_when_dirs_already_exist(self, tmp_path):  # FT-030
+        """Constructing QueueStorage twice on the same directory never raises."""
+        QueueStorage(str(tmp_path))
+        QueueStorage(str(tmp_path))
+
+
+# ===========================================================================
+# Manager-Level Behaviour Under Storage Errors
+# ===========================================================================
+
+
+class TestManagerErrors:
+    """FT-031..036: QueueManager behaviour when storage operations fail."""
+
+    @pytest.fixture()
+    def manager(self, tmp_path, mocker):
+        mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+        mocker.patch.object(
+            ClaudeCodeInterface, "test_connection", return_value=(True, "ok")
+        )
+        return QueueManager(storage_dir=str(tmp_path), claude_command="claude")
+
+    def test_add_prompt_returns_false_on_storage_failure(self, manager):  # FT-031
+        """add_prompt returns False when save_queue_state returns False."""
+        p = QueuedPrompt(content="new task")
+        manager.state = manager.storage.load_queue_state()
+
+        with patch.object(manager.storage, "save_queue_state", return_value=False):
+            result = manager.add_prompt(p)
+
+        assert result is False
+
+    def test_remove_prompt_returns_false_on_storage_failure(self, manager):  # FT-032
+        """remove_prompt returns False when save_queue_state returns False."""
+        p = QueuedPrompt(content="task")
+        manager.state = manager.storage.load_queue_state()
+        manager.state.add_prompt(p)
+
+        with patch.object(manager.storage, "save_queue_state", return_value=False):
+            result = manager.remove_prompt(p.id)
+
+        assert result is False
+
+    def test_shutdown_raises_when_save_queue_state_raises(self, manager):  # FT-033
+        """_shutdown propagates exceptions from save_queue_state (no try/except)."""
+        manager.state = QueueState()
+
+        with patch.object(
+            manager.storage,
+            "save_queue_state",
+            side_effect=Exception("disk error"),
+        ):
+            with pytest.raises(Exception, match="disk error"):
+                manager._shutdown()
+
+    def test_execute_prompt_raises_when_pre_execution_save_raises(self, manager):  # FT-034
+        """_execute_prompt propagates exception from pre-execution save_queue_state."""
+        manager.state = QueueState()
+        prompt = QueuedPrompt(content="task", status=PromptStatus.EXECUTING)
+        manager.state.add_prompt(prompt)
+
+        with patch.object(
+            manager.storage,
+            "save_queue_state",
+            side_effect=Exception("disk write failure"),
+        ):
+            with pytest.raises(Exception, match="disk write failure"):
+                manager._execute_prompt(prompt)
+
+    def test_process_queue_iteration_raises_when_post_execution_save_raises(self, manager):  # FT-035
+        """_process_queue_iteration propagates exception from post-execution save."""
+        state = manager.storage.load_queue_state()
+        p = QueuedPrompt(content="task")
+        state.add_prompt(p)
+        manager.storage.save_queue_state(state)
+
+        call_count = 0
+        real_save = manager.storage.save_queue_state
+
+        def save_side_effect(s):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise Exception("disk full")
+            return real_save(s)
+
+        with patch.object(
+            manager.claude_interface,
+            "execute_prompt",
+            return_value=ExecutionResult(
+                success=True, output="done", execution_time=0.1
+            ),
+        ):
+            with patch.object(
+                manager.storage, "save_queue_state", side_effect=save_side_effect
+            ):
+                manager.state = None
+                with pytest.raises(Exception, match="disk full"):
+                    manager._process_queue_iteration()
+
+    def test_process_queue_iteration_raises_when_load_raises(self, manager):  # FT-036
+        """_process_queue_iteration propagates exception from load_queue_state."""
+        with patch.object(
+            manager.storage,
+            "load_queue_state",
+            side_effect=Exception("disk unreadable"),
+        ):
+            with pytest.raises(Exception, match="disk unreadable"):
+                manager._process_queue_iteration()
+
+
+# ===========================================================================
+# Known Bugs (xfail)
+# ===========================================================================
+
+
+class TestKnownBugs:
+    """FT-037..043: real bugs discovered during test plan analysis."""
+
+    def test_remove_prompt_files_does_not_delete_files_with_prefix_match(self, tmp_path):  # FT-037
+        """BUG: glob pattern '{id}*.md' matches IDs that start with the given id.
+        Removing 'abc1' must NOT delete 'abc12345-task.md'.
+        """
+        storage = QueueStorage(str(tmp_path))
+        (storage.queue_dir / "abc1-task.md").write_text("content for abc1")
+        (storage.queue_dir / "abc12345-task.md").write_text("content for abc12345")
+
+        storage._remove_prompt_files("abc1", storage.queue_dir)
+
+        assert not (storage.queue_dir / "abc1-task.md").exists()
+        assert (storage.queue_dir / "abc12345-task.md").exists(), (
+            "BUG: prefix glob deleted file for a different prompt (abc12345 != abc1)"
+        )
+
+    def test_list_bank_templates_with_file_without_frontmatter(self, tmp_path):  # FT-038
+        """list_bank_templates must not skip a bank file that has no frontmatter.
+        Correct behavior: return the template with the filename as its title.
+        """
+        storage = QueueStorage(str(tmp_path))
+        (storage.bank_dir / "plain.md").write_text(
+            "Just plain text.\nNo frontmatter here."
+        )
+
+        templates = storage.list_bank_templates()
+
+        assert len(templates) == 1, (
+            "BUG: bank file without frontmatter silently skipped due to NameError in 'parts'"
+        )
+        assert templates[0]["name"] == "plain"
+
+    def test_write_prompt_file_leaves_partial_file_on_enospc_during_yaml_dump(self, tmp_path):  # FT-039
+        """write_prompt_file creates/truncates the file before yaml.dump is called.
+        If yaml.dump raises ENOSPC, a partial (invalid) file remains on disk.
+        """
+        storage = QueueStorage(str(tmp_path))
+        prompt = QueuedPrompt(id="abc12345", content="task")
+        file_path = storage.queue_dir / "abc12345-task.md"
+
+        with patch(
+            "claude_code_queue.storage.yaml.dump",
+            side_effect=OSError(errno.ENOSPC, os.strerror(errno.ENOSPC)),
+        ):
+            result = storage.parser.write_prompt_file(prompt, file_path)
+
+        assert result is False
+        assert file_path.exists(), "Partial file should exist after mid-write failure"
+        content = file_path.read_text()
+        assert content == "---\n", (
+            f"Expected only partial write '---\\n', got: {content!r}"
+        )
+
+    def test_save_queue_state_leaves_partial_json_on_enospc_during_json_dump(self, tmp_path):  # FT-040
+        """save_queue_state truncates queue-state.json before json.dump. If json.dump
+        raises ENOSPC the state file is empty — counter history is lost on next load.
+        """
+        storage = QueueStorage(str(tmp_path))
+        state = QueueState()
+        state.total_processed = 42
+        storage.save_queue_state(state)
+
+        with patch(
+            "claude_code_queue.storage.json.dump",
+            side_effect=OSError(errno.ENOSPC, os.strerror(errno.ENOSPC)),
+        ):
+            result = storage.save_queue_state(state)
+
+        assert result is False
+
+        content = storage.state_file.read_text()
+        assert len(content) == 0, (
+            "State file must be empty (truncated before json.dump failed)"
+        )
+
+        reloaded = storage.load_queue_state()
+        assert reloaded.total_processed == 0, (
+            "Counter history lost due to partial write"
+        )
+
+    def test_add_prompt_creates_memory_disk_inconsistency_on_save_failure(self, tmp_path, mocker):  # FT-041
+        """add_prompt adds the prompt to in-memory state BEFORE calling save_queue_state.
+        If save fails, memory and disk diverge.
+        """
+        mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+        mocker.patch.object(
+            ClaudeCodeInterface, "test_connection", return_value=(True, "ok")
+        )
+        manager = QueueManager(storage_dir=str(tmp_path), claude_command="claude")
+
+        p = QueuedPrompt(content="task")
+        manager.state = manager.storage.load_queue_state()
+
+        with patch.object(manager.storage, "save_queue_state", return_value=False):
+            result = manager.add_prompt(p)
+
+        assert result is False
+        assert any(pr.id == p.id for pr in manager.state.prompts), (
+            "Prompt was added to in-memory state even though disk save failed"
+        )
+
+        reloaded = manager.storage.load_queue_state()
+        assert not any(pr.id == p.id for pr in reloaded.prompts), (
+            "Prompt correctly absent from disk state (save failed)"
+        )
+
+    def test_create_prompt_template_path_traversal_blocked(self, tmp_path):  # FT-042
+        """BUG: create_prompt_template does not sanitize filenames. A path-traversal
+        name like '../../malicious' must not write outside queue_dir.
+        """
+        storage = QueueStorage(str(tmp_path))
+        evil_name = "../../malicious"
+
+        try:
+            storage.create_prompt_template(evil_name)
+        except Exception:
+            pass
+
+        evil_path = tmp_path.parent / "malicious.md"
+        assert not evil_path.exists(), (
+            "BUG: path traversal via template name allows writing outside queue_dir"
+        )
+
+    def test_save_prompt_to_bank_path_traversal_blocked(self, tmp_path):  # FT-043
+        """BUG: save_prompt_to_bank does not sanitize template_name. A path-traversal
+        name like '../../malicious' must not write outside bank_dir.
+        """
+        storage = QueueStorage(str(tmp_path))
+        evil_name = "../../malicious"
+
+        try:
+            storage.save_prompt_to_bank(evil_name)
+        except Exception:
+            pass
+
+        evil_path = tmp_path.parent / "malicious.md"
+        assert not evil_path.exists(), (
+            "BUG: path traversal via template_name allows writing outside bank_dir"
+        )
+
+
+# ===========================================================================
+# Subprocess Death (T01–T13)
+# ===========================================================================
+
+
+def test_subprocess_nonzero_returncode_yields_failure_result(iface, mocker, tmp_path):  # FT-044
+    """returncode=137 (SIGKILL) → success=False and is_rate_limited=False."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.return_value = MagicMock(returncode=137, stdout="", stderr="Killed")
+
+    prompt = QueuedPrompt(
+        id="t01aaaa", content="fix a bug", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.success is False
+    assert result.is_rate_limited is False
+    assert "Killed" in result.error or result.error == ""
+
+
+def test_subprocess_timeout_returns_timeout_failure(iface, mocker, tmp_path):  # FT-045
+    """subprocess.TimeoutExpired is caught and returned as a failure, not re-raised."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+
+    prompt = QueuedPrompt(
+        id="t02aaaa", content="some task", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.success is False
+    assert result.is_rate_limited is False
+    assert "timed out" in result.error.lower()
+    assert result.execution_time >= 0
+
+
+def test_subprocess_oserror_returns_failure_not_exception(iface, mocker, tmp_path):  # FT-046
+    """OSError inside execute_prompt() is caught and returned as failure."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = OSError("Connection reset by peer")
+
+    prompt = QueuedPrompt(
+        id="t03aaaa", content="some task", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.success is False
+    assert "Connection reset by peer" in result.error
+
+
+def test_subprocess_generic_exception_returns_failure(iface, mocker, tmp_path):  # FT-047
+    """RuntimeError inside execute_prompt() is caught via generic except clause."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = RuntimeError("unexpected internal error")
+
+    prompt = QueuedPrompt(
+        id="t04aaaa", content="task", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.success is False
+    assert "unexpected internal error" in result.error
+
+
+def test_working_dir_restored_after_subprocess_timeout(iface, mocker, tmp_path):  # FT-048
+    """os.getcwd() is unchanged after TimeoutExpired (cwd= param, not os.chdir)."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    original_cwd = os.getcwd()
+
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+
+    prompt = QueuedPrompt(
+        id="t05aaaa", content="task", working_directory=str(work_dir)
+    )
+    iface.execute_prompt(prompt)
+
+    assert os.getcwd() == original_cwd
+
+
+def test_working_dir_restored_after_generic_exception(iface, mocker, tmp_path):  # FT-049
+    """os.getcwd() is unchanged after RuntimeError (cwd= param, not os.chdir)."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    original_cwd = os.getcwd()
+
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = RuntimeError("boom")
+
+    prompt = QueuedPrompt(
+        id="t06aaaa", content="task", working_directory=str(work_dir)
+    )
+    iface.execute_prompt(prompt)
+
+    assert os.getcwd() == original_cwd
+
+
+def test_execute_prompt_returncode_137_not_rate_limited(iface, mocker, tmp_path):  # FT-050
+    """SIGKILL exit (returncode 137) with 'Killed' in stdout is NOT rate-limited."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.return_value = MagicMock(returncode=137, stdout="Killed", stderr="")
+
+    prompt = QueuedPrompt(
+        id="t07aaaa", content="some work", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.is_rate_limited is False
+
+
+def test_detect_rate_limit_not_triggered_by_empty_output(iface):  # FT-051
+    """Empty string passed to _detect_rate_limit() returns is_rate_limited=False."""
+    info = iface._detect_rate_limit("")
+    assert info.is_rate_limited is False
+
+
+def test_failed_subprocess_with_retries_remaining_queues_retry(mgr, mock_iface, tmp_path):  # FT-052
+    """After a subprocess failure with retries remaining, prompt goes back to QUEUED."""
+    mock_iface.execute_prompt.return_value = _fail_result("exit 1")
+
+    prompt = QueuedPrompt(
+        id="t09aaaa", content="do something", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+    mgr.state = None
+
+    mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.QUEUED
+    assert mgr.state.prompts[0].retry_count == 1
+    assert mgr.state.failed_count == 0
+
+
+def test_failed_subprocess_exhausting_retries_marks_failed(mgr, mock_iface):  # FT-053
+    """When retry_count == max_retries before execution, next failure is permanent FAILED."""
+    mock_iface.execute_prompt.return_value = _fail_result("exit 1")
+
+    prompt = QueuedPrompt(
+        id="t10aaaa", content="do something", max_retries=3, retry_count=3
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+    mgr.state = None
+
+    mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.FAILED
+    assert mgr.state.failed_count == 1
+
+
+def test_timeout_failure_with_retries_remaining_queues_retry(mgr, mock_iface):  # FT-054
+    """A timeout ExecutionResult with retries remaining puts the prompt back to QUEUED."""
+    mock_iface.execute_prompt.return_value = _timeout_result()
+
+    prompt = QueuedPrompt(
+        id="t11aaaa", content="long task", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+    mgr.state = None
+
+    mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.QUEUED
+    assert mgr.state.prompts[0].retry_count == 1
+
+
+def test_repeated_subprocess_kills_exhaust_retries_and_fail(mgr, mock_iface):  # FT-055
+    """Subprocess killed on every attempt: after max_retries the prompt is FAILED."""
+    mock_iface.execute_prompt.return_value = _fail_result("killed")
+
+    prompt = QueuedPrompt(
+        id="t12aaaa", content="work", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+
+    for _ in range(3):
+        mgr.state = None
+        mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.FAILED
+    assert mgr.state.prompts[0].retry_count == 3
+    assert mgr.state.failed_count == 1
+
+
+def test_subprocess_kill_status_preserved_across_disk_roundtrip(mgr, mock_iface, tmp_path):  # FT-056
+    """retry_count is persisted in YAML and survives a save → load roundtrip."""
+    mock_iface.execute_prompt.return_value = _fail_result("killed")
+
+    prompt = QueuedPrompt(
+        id="t13aaaa", content="important work", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+    mgr.state = None
+
+    mgr._process_queue_iteration()
+
+    reloaded = mgr.storage.load_queue_state()
+    assert reloaded.prompts[0].status == PromptStatus.QUEUED
+    assert reloaded.prompts[0].retry_count == 1
+
+
+# ===========================================================================
+# SIGKILL / Crash Recovery (T14–T23)
+# ===========================================================================
+
+
+class TestSIGKILLRecovery:
+    """FT-057..066: filesystem state left after the entire queue daemon is killed.
+
+    The defining artifact is an orphaned .executing.md file in the queue directory.
+    """
+
+    @pytest.fixture
+    def mgr(self, tmp_path, mock_iface):
+        """QueueManager with running=True (needed for shutdown tests)."""
+        m = QueueManager.__new__(QueueManager)
+        m.storage = QueueStorage(str(tmp_path))
+        m.claude_interface = mock_iface
+        m.check_interval = 30
+        m.running = True
+        m.state = None
+        return m
+
+    def test_orphaned_executing_file_present_after_sigkill_simulation(self, storage):  # FT-057
+        """Baseline: writing a .executing.md creates the expected orphaned file."""
+        exec_file = storage.queue_dir / "t14aaaa-do-work.executing.md"
+        exec_file.write_text(
+            "---\n"
+            "priority: 0\n"
+            "working_directory: .\n"
+            "max_retries: 3\n"
+            "status: executing\n"
+            "retry_count: 1\n"
+            "created_at: 2025-01-01T00:00:00\n"
+            "---\n\n"
+            "do work"
+        )
+
+        assert exec_file.exists() is True
+        plain = storage.queue_dir / "t14aaaa-do-work.md"
+        assert plain.exists() is False
+
+    def test_sigkill_orphan_loaded_as_queued_not_executing(self, storage):  # FT-058
+        """Orphaned .executing.md is loaded as QUEUED, not stuck EXECUTING."""
+        _write_executing_file(storage.queue_dir, "t14aaaa", "do-work")
+
+        state = storage.load_queue_state()
+
+        assert len(state.prompts) == 1
+        assert state.prompts[0].status == PromptStatus.QUEUED
+        assert state.get_next_prompt() is not None
+
+    def test_sigkill_orphan_recovered_as_queued_after_fix(self, storage):  # FT-059
+        """A .executing.md left by a crash is loaded as status=QUEUED."""
+        _write_executing_file(storage.queue_dir, "t14aaaa", "do-work")
+
+        state = storage.load_queue_state()
+
+        assert len(state.prompts) == 1
+        assert state.prompts[0].status == PromptStatus.QUEUED
+        assert state.prompts[0].id == "t14aaaa"
+        assert state.get_next_prompt() is not None
+
+    def test_sigkill_orphan_gets_recovery_log_entry(self, storage):  # FT-060
+        """Recovered prompt has an execution_log entry containing 'ecovered'."""
+        _write_executing_file(storage.queue_dir, "t14aaaa", "do-work")
+
+        state = storage.load_queue_state()
+
+        log = state.prompts[0].execution_log
+        assert "ecovered" in log.lower() or "Recovered" in log, (
+            f"Expected 'Recovered'/'ecovered' in log, got: {log!r}"
+        )
+
+    def test_multiple_sigkill_orphans_all_recovered(self, storage):  # FT-061
+        """All .executing.md orphans are recovered as QUEUED on load."""
+        pairs = [
+            ("aaa11111", "task-one"),
+            ("bbb22222", "task-two"),
+            ("ccc33333", "task-three"),
+        ]
+        for pid, name in pairs:
+            _write_executing_file(storage.queue_dir, pid, name, content=name)
+
+        state = storage.load_queue_state()
+
+        assert len(state.prompts) == 3
+        assert all(p.status == PromptStatus.QUEUED for p in state.prompts)
+        loaded_ids = {p.id for p in state.prompts}
+        assert loaded_ids == {"aaa11111", "bbb22222", "ccc33333"}
+
+    def test_sigkill_orphan_does_not_duplicate_with_plain_md(self, storage):  # FT-062
+        """If both .executing.md and plain .md exist for the same ID, only one is loaded."""
+        content = (
+            "---\n"
+            "priority: 0\n"
+            "working_directory: .\n"
+            "max_retries: 3\n"
+            "status: queued\n"
+            "retry_count: 0\n"
+            "created_at: 2025-01-01T00:00:00\n"
+            "---\n\n"
+            "my task"
+        )
+        exec_file = storage.queue_dir / "t19aaaa-my-task.executing.md"
+        plain_file = storage.queue_dir / "t19aaaa-my-task.md"
+        exec_file.write_text(content)
+        plain_file.write_text(content)
+
+        state = storage.load_queue_state()
+
+        copies = [p for p in state.prompts if p.id == "t19aaaa"]
+        assert len(copies) == 1, (
+            f"Expected exactly 1 copy of t19aaaa, found {len(copies)}"
+        )
+
+    def test_sigkill_with_corrupted_executing_file_skipped_gracefully(self, storage):  # FT-063
+        """Corrupted YAML in a .executing.md does not raise; valid prompts still load."""
+        bad_file = storage.queue_dir / "t20aaaa-bad-prompt.executing.md"
+        bad_file.write_text("---\nthis: is: not: valid: yaml: [\n---\n\nbody")
+
+        good_file = storage.queue_dir / "t21bbbb-good-prompt.md"
+        good_file.write_text(
+            "---\n"
+            "priority: 0\n"
+            "working_directory: .\n"
+            "max_retries: 3\n"
+            "status: queued\n"
+            "retry_count: 0\n"
+            "created_at: 2025-01-01T00:00:00\n"
+            "---\n\n"
+            "good task"
+        )
+
+        state = storage.load_queue_state()
+
+        good_prompts = [p for p in state.prompts if p.id == "t21bbbb"]
+        assert len(good_prompts) == 1, "Valid prompt was not loaded"
+
+    def test_sigkill_orphan_is_dispatchable_after_fix(self, storage):  # FT-064
+        """With crash recovery applied, orphaned .executing.md IS dispatchable."""
+        exec_file = storage.queue_dir / "t21aaaa-stuck.executing.md"
+        exec_file.write_text(
+            "---\n"
+            "priority: 0\n"
+            "working_directory: .\n"
+            "max_retries: 3\n"
+            "status: executing\n"
+            "retry_count: 0\n"
+            "created_at: 2025-01-01T00:00:00\n"
+            "---\n\n"
+            "stuck task"
+        )
+
+        state = storage.load_queue_state()
+
+        assert state.prompts[0].status == PromptStatus.QUEUED
+        assert state.get_next_prompt() is not None
+
+    def test_graceful_ctrl_c_shutdown_removes_executing_file(self, mgr):  # FT-065
+        """_shutdown() transitions EXECUTING → QUEUED and removes the .executing.md file."""
+        storage = mgr.storage
+
+        prompt = QueuedPrompt(
+            id="t22aaaa", content="active task", status=PromptStatus.EXECUTING
+        )
+        exec_path = storage.queue_dir / "t22aaaa-active-task.executing.md"
+        MarkdownPromptParser.write_prompt_file(prompt, exec_path)
+        assert exec_path.exists()
+
+        state = QueueState()
+        state.add_prompt(prompt)
+        mgr.state = state
+
+        mgr._shutdown()
+
+        assert exec_path.exists() is False, ".executing.md must be removed by _shutdown()"
+        plain_files = [
+            f
+            for f in storage.queue_dir.glob("t22aaaa*.md")
+            if not f.name.endswith(".executing.md")
+        ]
+        assert len(plain_files) == 1, (
+            f"Expected exactly one plain .md, found: {plain_files}"
+        )
+        assert mgr.state.prompts[0].status == PromptStatus.QUEUED
+
+    def test_graceful_shutdown_multiple_in_flight_prompts(self, mgr):  # FT-066
+        """All EXECUTING prompts become QUEUED and their .executing.md files are removed."""
+        storage = mgr.storage
+
+        prompts_cfg = [
+            ("t23aaaa", "task-alpha"),
+            ("t23bbbb", "task-beta"),
+            ("t23cccc", "task-gamma"),
+        ]
+
+        exec_paths = []
+        state = QueueState()
+        for pid, slug in prompts_cfg:
+            prompt = QueuedPrompt(
+                id=pid, content=slug.replace("-", " "), status=PromptStatus.EXECUTING
+            )
+            exec_path = storage.queue_dir / f"{pid}-{slug}.executing.md"
+            MarkdownPromptParser.write_prompt_file(prompt, exec_path)
+            exec_paths.append(exec_path)
+            state.add_prompt(prompt)
+
+        mgr.state = state
+        mgr._shutdown()
+
+        for path in exec_paths:
+            assert path.exists() is False, f"{path.name} must be removed by _shutdown()"
+
+        for pid, _ in prompts_cfg:
+            plain_files = [
+                f
+                for f in storage.queue_dir.glob(f"{pid}*.md")
+                if not f.name.endswith(".executing.md")
+            ]
+            assert len(plain_files) == 1, (
+                f"Expected one plain .md for {pid}, found: {plain_files}"
+            )
+
+        assert all(p.status == PromptStatus.QUEUED for p in mgr.state.prompts)
+
+
+# ===========================================================================
+# Network Failures (T24–T31)
+# ===========================================================================
+
+
+def test_network_timeout_during_execution_returns_failure(iface, mocker, tmp_path):  # FT-067
+    """Hung network call → TimeoutExpired → caught as failure, not re-raised."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd=["claude", "--print", "..."], timeout=3600
+    )
+
+    prompt = QueuedPrompt(
+        id="t24aaaa", content="fetch data", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.success is False
+    assert result.is_rate_limited is False
+    assert "timed out" in result.error.lower()
+
+
+def test_network_failure_nonzero_returncode_not_rate_limited(iface, mocker, tmp_path):  # FT-068
+    """returncode=1 with DNS error in stderr → failure, not rate-limited."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="",
+        stderr="curl: (6) Could not resolve host: api.anthropic.com",
+    )
+
+    prompt = QueuedPrompt(
+        id="t25aaaa", content="some task", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.success is False
+    assert result.is_rate_limited is False
+
+
+@pytest.mark.parametrize(
+    "output_string",
+    [
+        "curl: (6) Could not resolve host: api.anthropic.com",
+        "connect: Connection timed out",
+        "network unreachable",
+        "ssl: handshake failure",
+        "",
+        "Killed",
+    ],
+)
+def test_network_failure_output_does_not_match_rate_limit_keywords(iface, output_string):  # FT-069
+    """Typical network-error strings are NOT classified as rate-limited."""
+    info = iface._detect_rate_limit(output_string)
+    assert info.is_rate_limited is False, (
+        f"False positive: {output_string!r} incorrectly triggered rate-limit detection"
+    )
+
+
+def test_startup_connection_failure_prevents_queue_loop(tmp_path):  # FT-070
+    """If test_connection() fails, start() exits before executing any prompts."""
+    mock_iface = MagicMock(spec=ClaudeCodeInterface)
+    mock_iface.test_connection.return_value = (
+        False,
+        "Claude Code CLI error: network unreachable",
+    )
+
+    manager = QueueManager.__new__(QueueManager)
+    manager.storage = QueueStorage(str(tmp_path))
+    manager.claude_interface = mock_iface
+    manager.check_interval = 30
+    manager.running = False
+    manager.state = None
+
+    manager.start()
+
+    assert mock_iface.execute_prompt.call_count == 0
+    assert manager.running is False
+
+
+def test_verify_connection_timeout_returns_false(iface, mocker):  # FT-071
+    """test_connection() TimeoutExpired → returns (False, '...timed out...')."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd=["claude", "--help"], timeout=10
+    )
+
+    ok, msg = iface.test_connection()
+
+    assert ok is False
+    assert "timed out" in msg.lower(), f"Expected 'timed out' in {msg!r}"
+
+
+def test_network_loss_mid_execution_retries_after_fix(mgr, mock_iface):  # FT-072
+    """Network failure with retries remaining → prompt back to QUEUED."""
+    mock_iface.execute_prompt.return_value = _network_fail_result()
+
+    prompt = QueuedPrompt(
+        id="t29aaaa", content="fetch data", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+    mgr.state = None
+
+    mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.QUEUED
+    assert mgr.state.prompts[0].retry_count == 1
+
+
+def test_repeated_network_failures_exhaust_retries(mgr, mock_iface):  # FT-073
+    """Extended network outage: after max_retries the prompt is permanently FAILED."""
+    mock_iface.execute_prompt.return_value = _network_fail_result()
+
+    prompt = QueuedPrompt(
+        id="t30aaaa", content="network task", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+
+    for _ in range(3):
+        mgr.state = None
+        mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.FAILED
+    assert mgr.state.failed_count == 1
+
+
+def test_network_restored_prompt_succeeds_on_retry(mgr, mock_iface):  # FT-074
+    """First attempt fails (network error), second attempt succeeds → COMPLETED."""
+    mock_iface.execute_prompt.side_effect = [
+        _network_fail_result(),
+        _success_result(),
+    ]
+
+    prompt = QueuedPrompt(
+        id="t31aaaa", content="fetch data", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+
+    mgr.state = None
+    mgr._process_queue_iteration()
+    assert mgr.state.prompts[0].status == PromptStatus.QUEUED
+
+    mgr.state = None
+    mgr._process_queue_iteration()
+
+    assert mgr.state.total_processed == 1
+
+
+# ===========================================================================
+# Authentication Failures (T32–T40)
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "error_string",
+    [
+        "Error: Not authenticated. Please run 'claude login'.",
+        "authentication failed",
+        "Unauthorized: invalid API key",
+        "Error: API key is invalid or has been revoked",
+        "403 Forbidden",
+        "401 Unauthorized",
+        "Error: Your session has expired. Please log in again.",
+    ],
+)
+def test_auth_error_text_not_classified_as_rate_limit(iface, error_string):  # FT-075
+    """Authentication error messages do NOT match rate-limit indicators."""
+    info = iface._detect_rate_limit(error_string)
+    assert info.is_rate_limited is False, (
+        f"False positive: auth string {error_string!r} triggered rate-limit detection"
+    )
+
+
+def test_auth_failure_returncode_nonzero_produces_failure_result(iface, mocker, tmp_path):  # FT-076
+    """returncode=1 with auth error in stderr → success=False, is_rate_limited=False."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="",
+        stderr="Error: Not authenticated. Please run 'claude login'.",
+    )
+
+    prompt = QueuedPrompt(
+        id="t33aaaa", content="task", working_directory=str(tmp_path)
+    )
+    result = iface.execute_prompt(prompt)
+
+    assert result.success is False
+    assert result.is_rate_limited is False
+    assert "Not authenticated" in result.error
+
+
+def test_verify_claude_unavailable_raises_runtime_error(mocker):  # FT-077
+    """FileNotFoundError from subprocess during _verify_claude_available → RuntimeError."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.side_effect = FileNotFoundError("No such file or directory: 'claude'")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        ClaudeCodeInterface("claude", 60)
+
+    msg = str(exc_info.value).lower()
+    assert "not found" in msg or "path" in msg, (
+        f"Expected 'not found'/'path' in error: {exc_info.value}"
+    )
+
+
+def test_verify_claude_version_nonzero_raises_runtime_error(mocker):  # FT-078
+    """Non-zero returncode from claude --version during __init__ → RuntimeError."""
+    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
+    mock_run.return_value = MagicMock(
+        returncode=1, stdout="", stderr="configuration error"
+    )
+
+    with pytest.raises(RuntimeError):
+        ClaudeCodeInterface("claude", 60)
+
+
+def test_startup_auth_failure_prevents_start(tmp_path):  # FT-079
+    """If test_connection() returns auth failure, start() exits without executing."""
+    mock_iface = MagicMock(spec=ClaudeCodeInterface)
+    mock_iface.test_connection.return_value = (
+        False,
+        "Claude Code CLI error: Error: Not authenticated.",
+    )
+
+    manager = QueueManager.__new__(QueueManager)
+    manager.storage = QueueStorage(str(tmp_path))
+    manager.claude_interface = mock_iface
+    manager.check_interval = 30
+    manager.running = False
+    manager.state = None
+
+    manager.start()
+
+    assert mock_iface.execute_prompt.call_count == 0
+    assert manager.running is False
+
+
+def test_wrong_credentials_first_attempt_fails(mgr, mock_iface):  # FT-080
+    """Wrong API key: first failure with retries remaining → QUEUED."""
+    mock_iface.execute_prompt.return_value = _auth_fail_result(
+        "Unauthorized: invalid API key"
+    )
+
+    prompt = QueuedPrompt(
+        id="t37aaaa", content="task", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+    mgr.state = None
+
+    mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.QUEUED
+    assert mgr.state.prompts[0].retry_count == 1
+    assert mgr.state.failed_count == 0
+
+
+def test_wrong_credentials_exhaust_retries_marks_failed(mgr, mock_iface):  # FT-081
+    """Wrong credentials: after max_retries the prompt is permanently FAILED."""
+    mock_iface.execute_prompt.return_value = _auth_fail_result(
+        "Unauthorized: invalid API key"
+    )
+
+    prompt = QueuedPrompt(
+        id="t38aaaa", content="task", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+
+    for _ in range(3):
+        mgr.state = None
+        mgr._process_queue_iteration()
+
+    assert mgr.state.prompts[0].status == PromptStatus.FAILED
+    assert mgr.state.failed_count == 1
+    assert mgr.state.prompts[0].retry_count == 3
+
+
+def test_interrupted_auth_session_mid_queue(mgr, mock_iface):  # FT-082
+    """Token expires between tasks: first COMPLETED, second QUEUED for retry."""
+    mock_iface.execute_prompt.side_effect = [
+        _success_result("done"),
+        _auth_fail_result("session expired"),
+    ]
+
+    prompt1 = QueuedPrompt(
+        id="t39aaaa", content="task one", priority=0, max_retries=3
+    )
+    prompt2 = QueuedPrompt(
+        id="t39bbbb", content="task two", priority=1, max_retries=3
+    )
+    state = QueueState()
+    state.add_prompt(prompt1)
+    state.add_prompt(prompt2)
+    mgr.storage.save_queue_state(state)
+
+    mgr.state = None
+    mgr._process_queue_iteration()
+    assert mgr.state.total_processed == 1
+
+    mgr.state = None
+    mgr._process_queue_iteration()
+
+    p2 = mgr.state.prompts[0]
+    assert p2.id == "t39bbbb"
+    assert p2.status == PromptStatus.QUEUED
+    assert mgr.state.total_processed == 1
+    assert mgr.state.failed_count == 0
+
+
+def test_auth_failure_not_rate_limit_counter_not_incremented(mgr, mock_iface):  # FT-083
+    """Auth failure must not increment state.rate_limited_count."""
+    mock_iface.execute_prompt.return_value = _auth_fail_result()
+
+    prompt = QueuedPrompt(
+        id="t40aaaa", content="task", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    mgr.storage.save_queue_state(state)
+    mgr.state = None
+
+    mgr._process_queue_iteration()
+
+    assert mgr.state.rate_limited_count == 0
+
+
+# ===========================================================================
+# Complex Failure Scenarios (T41–T42)
+# ===========================================================================
+
+
+def test_sigkill_during_auth_failure_retry_cycle(tmp_path):  # FT-084
+    """Prompt fails with auth error → QUEUED for retry. Before the next tick,
+    process is killed (simulated by writing .executing.md with retry_count=1).
+    On restart, the orphan is recovered as QUEUED with retry_count=1 intact.
+    """
+    storage = QueueStorage(str(tmp_path))
+
+    exec_file = storage.queue_dir / "t41aaaa-auth-task.executing.md"
+    exec_file.write_text(
+        "---\n"
+        "priority: 0\n"
+        "working_directory: .\n"
+        "max_retries: 3\n"
+        "status: executing\n"
+        "retry_count: 1\n"
+        "created_at: 2025-01-01T00:00:00\n"
+        "---\n\n"
+        "auth task"
+    )
+
+    state = storage.load_queue_state()
+
+    assert len(state.prompts) == 1
+    p = state.prompts[0]
+    assert p.status == PromptStatus.QUEUED
+    assert p.retry_count == 1
+    assert p.can_retry() is True
+
+
+def test_network_loss_then_sigkill_then_restart_full_recovery(tmp_path, mock_iface):  # FT-085
+    """Full scenario:
+    1. Prompt queued.
+    2. First execution: network failure.
+    3. Prompt goes to QUEUED for retry (retry_count=1).
+    4. SIGKILL before second execution completes
+       (.executing.md with retry_count=2 left on disk).
+    5. Restart: prompt recovered as QUEUED with retry_count=2.
+    6. Second execution succeeds → COMPLETED.
+    """
+    storage = QueueStorage(str(tmp_path))
+
+    mock_iface.execute_prompt.return_value = _fail_result(
+        "curl: (6) Could not resolve host: api.anthropic.com"
+    )
+
+    mgr1 = QueueManager.__new__(QueueManager)
+    mgr1.storage = storage
+    mgr1.claude_interface = mock_iface
+    mgr1.check_interval = 30
+    mgr1.running = False
+    mgr1.state = None
+
+    prompt = QueuedPrompt(
+        id="t42aaaa", content="fetch data", max_retries=3, retry_count=0
+    )
+    state = QueueState()
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+
+    mgr1._process_queue_iteration()
+
+    p = mgr1.state.prompts[0]
+    assert p.status == PromptStatus.QUEUED
+    assert p.retry_count == 1
+
+    for f in storage.queue_dir.glob("t42aaaa*.md"):
+        f.unlink()
+
+    exec_file = storage.queue_dir / "t42aaaa-fetch-data.executing.md"
+    exec_file.write_text(
+        "---\n"
+        "priority: 0\n"
+        "working_directory: .\n"
+        "max_retries: 3\n"
+        "status: executing\n"
+        "retry_count: 2\n"
+        "created_at: 2025-01-01T00:00:00\n"
+        "---\n\n"
+        "fetch data"
+    )
+
+    reloaded_state = storage.load_queue_state()
+
+    assert len(reloaded_state.prompts) == 1
+    recovered = reloaded_state.prompts[0]
+    assert recovered.status == PromptStatus.QUEUED
+    assert recovered.retry_count == 2
+    assert recovered.can_retry() is True
+
+    mock_iface.execute_prompt.return_value = _success_result()
+
+    mgr2 = QueueManager.__new__(QueueManager)
+    mgr2.storage = storage
+    mgr2.claude_interface = mock_iface
+    mgr2.check_interval = 30
+    mgr2.running = False
+    mgr2.state = None
+
+    mgr2._process_queue_iteration()
+
+    assert mgr2.state.total_processed == 1

--- a/tests/test_fault_tolerance.py
+++ b/tests/test_fault_tolerance.py
@@ -23,6 +23,7 @@ import builtins
 import errno
 import os
 import subprocess
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -172,6 +173,7 @@ def mgr(tmp_path, mock_iface):
     m.check_interval = 30
     m.running = False
     m.state = None
+    m._generic_failure_retry_delay = 60  # Fix 3: __new__ bypasses __init__
     return m
 
 
@@ -1149,6 +1151,12 @@ def test_repeated_subprocess_kills_exhaust_retries_and_fail(mgr, mock_iface):  #
     for _ in range(3):
         mgr.state = None
         mgr._process_queue_iteration()
+        # Fix 3: simulate passage of time past retry_not_before.
+        if mgr.state:
+            for pr in mgr.state.prompts:
+                if pr.retry_not_before is not None:
+                    pr.retry_not_before = datetime.now() - timedelta(seconds=1)
+            mgr.storage.save_queue_state(mgr.state)
 
     assert mgr.state.prompts[0].status == PromptStatus.FAILED
     assert mgr.state.prompts[0].retry_count == 3
@@ -1194,6 +1202,7 @@ class TestSIGKILLRecovery:
         m.check_interval = 30
         m.running = True
         m.state = None
+        m._generic_failure_retry_delay = 60  # Fix 3: __new__ bypasses __init__
         return m
 
     def test_orphaned_executing_file_present_after_sigkill_simulation(self, storage):  # FT-057
@@ -1473,6 +1482,7 @@ def test_startup_connection_failure_prevents_queue_loop(tmp_path):  # FT-070
     manager.check_interval = 30
     manager.running = False
     manager.state = None
+    manager._generic_failure_retry_delay = 60  # Fix 3: __new__ bypasses __init__
 
     manager.start()
 
@@ -1525,6 +1535,12 @@ def test_repeated_network_failures_exhaust_retries(mgr, mock_iface):  # FT-073
     for _ in range(3):
         mgr.state = None
         mgr._process_queue_iteration()
+        # Fix 3: simulate passage of time past retry_not_before.
+        if mgr.state:
+            for pr in mgr.state.prompts:
+                if pr.retry_not_before is not None:
+                    pr.retry_not_before = datetime.now() - timedelta(seconds=1)
+            mgr.storage.save_queue_state(mgr.state)
 
     assert mgr.state.prompts[0].status == PromptStatus.FAILED
     assert mgr.state.failed_count == 1
@@ -1547,6 +1563,12 @@ def test_network_restored_prompt_succeeds_on_retry(mgr, mock_iface):  # FT-074
     mgr.state = None
     mgr._process_queue_iteration()
     assert mgr.state.prompts[0].status == PromptStatus.QUEUED
+
+    # Fix 3: simulate passage of time past retry_not_before.
+    for pr in mgr.state.prompts:
+        if pr.retry_not_before is not None:
+            pr.retry_not_before = datetime.now() - timedelta(seconds=1)
+    mgr.storage.save_queue_state(mgr.state)
 
     mgr.state = None
     mgr._process_queue_iteration()
@@ -1637,6 +1659,7 @@ def test_startup_auth_failure_prevents_start(tmp_path):  # FT-079
     manager.check_interval = 30
     manager.running = False
     manager.state = None
+    manager._generic_failure_retry_delay = 60  # Fix 3: __new__ bypasses __init__
 
     manager.start()
 
@@ -1681,6 +1704,12 @@ def test_wrong_credentials_exhaust_retries_marks_failed(mgr, mock_iface):  # FT-
     for _ in range(3):
         mgr.state = None
         mgr._process_queue_iteration()
+        # Fix 3: simulate passage of time past retry_not_before.
+        if mgr.state:
+            for pr in mgr.state.prompts:
+                if pr.retry_not_before is not None:
+                    pr.retry_not_before = datetime.now() - timedelta(seconds=1)
+            mgr.storage.save_queue_state(mgr.state)
 
     assert mgr.state.prompts[0].status == PromptStatus.FAILED
     assert mgr.state.failed_count == 1
@@ -1792,6 +1821,7 @@ def test_network_loss_then_sigkill_then_restart_full_recovery(tmp_path, mock_ifa
     mgr1.check_interval = 30
     mgr1.running = False
     mgr1.state = None
+    mgr1._generic_failure_retry_delay = 60  # Fix 3: __new__ bypasses __init__
 
     prompt = QueuedPrompt(
         id="t42aaaa", content="fetch data", max_retries=3, retry_count=0
@@ -1838,6 +1868,7 @@ def test_network_loss_then_sigkill_then_restart_full_recovery(tmp_path, mock_ifa
     mgr2.check_interval = 30
     mgr2.running = False
     mgr2.state = None
+    mgr2._generic_failure_retry_delay = 60  # Fix 3: __new__ bypasses __init__
 
     mgr2._process_queue_iteration()
 
@@ -1890,3 +1921,93 @@ def test_nested_session_error_not_picked_up_again(tmp_path, mocker):  # FT-087
 
     # execute_prompt must have been called exactly once
     assert execute_mock.call_count == 1
+
+
+# ===========================================================================
+# Fix 3 — Retry Backoff (FT-088..091)
+# ===========================================================================
+
+
+def test_use_bank_template_clears_retry_not_before(tmp_path):  # FT-088
+    """use_bank_template() must clear retry_not_before so newly-queued prompts
+    from templates are immediately eligible for execution.
+    """
+    storage = QueueStorage(str(tmp_path))
+    future_dt = (datetime.now() + timedelta(hours=1)).isoformat()
+    bank_file = storage.bank_dir / "my-template.md"
+    bank_file.write_text(
+        f"---\npriority: 0\nworking_directory: .\nmax_retries: 3\n"
+        f"retry_count: 0\ncreated_at: '2025-01-01T00:00:00'\n"
+        f"retry_not_before: '{future_dt}'\n---\n\ntask content"
+    )
+    prompt = storage.use_bank_template("my-template")
+    assert prompt is not None
+    assert prompt.retry_not_before is None, (
+        "use_bank_template() must clear retry_not_before from bank template frontmatter"
+    )
+
+
+def test_retry_not_before_survives_reload(tmp_path):  # FT-089
+    """retry_not_before must be preserved across a save+load cycle."""
+    storage = QueueStorage(str(tmp_path))
+    future = datetime.now() + timedelta(minutes=5)
+    p = QueuedPrompt(id="rrr12345", content="cooldown task", retry_not_before=future)
+    state = QueueState()
+    state.add_prompt(p)
+    storage.save_queue_state(state)
+
+    reloaded = storage.load_queue_state()
+    recovered = next(pr for pr in reloaded.prompts if pr.id == p.id)
+    assert recovered.retry_not_before is not None
+    assert recovered.retry_not_before > datetime.now()
+
+
+def test_generic_failure_unlimited_retries_respects_backoff(tmp_path, mocker):  # FT-090
+    """With max_retries=-1, each failure sets retry_not_before so the prompt
+    cannot be selected again until the delay expires.
+    Two iteration calls without clearing retry_not_before → execute_prompt
+    called exactly once.
+    """
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    mgr = QueueManager(storage_dir=str(tmp_path), generic_failure_retry_delay=3600)
+
+    p = QueuedPrompt(id="spin01", content="always fails", max_retries=-1)
+    mgr.state = mgr.storage.load_queue_state()
+    mgr.state.add_prompt(p)
+    mgr.storage.save_queue_state(mgr.state)
+
+    execute_mock = mocker.patch.object(
+        mgr.claude_interface,
+        "execute_prompt",
+        return_value=ExecutionResult(
+            success=False, output="", error="persistent error", execution_time=2.0
+        )
+    )
+
+    mgr._process_queue_iteration()  # executes, sets retry_not_before
+    mgr.state = None
+    mgr._process_queue_iteration()  # retry_not_before in future — skipped
+
+    assert execute_mock.call_count == 1
+
+
+def test_crash_recovery_clears_retry_not_before(tmp_path):  # FT-091
+    """After a crash, .executing.md files are recovered to QUEUED status.
+    retry_not_before must be cleared in the recovery path so the prompt is
+    immediately eligible for re-execution.
+    """
+    storage = QueueStorage(str(tmp_path))
+    future = datetime.now() + timedelta(hours=1)
+    p = QueuedPrompt(id="crash01", content="crashed task", max_retries=3)
+    p.retry_not_before = future
+    p.status = PromptStatus.EXECUTING
+    base = MarkdownPromptParser.get_base_filename(p).replace(".md", ".executing.md")
+    exec_path = storage.queue_dir / base
+    storage.parser.write_prompt_file(p, exec_path)
+
+    reloaded = storage.load_queue_state()
+    recovered = next(pr for pr in reloaded.prompts if pr.id == p.id)
+    assert recovered.status == PromptStatus.QUEUED
+    assert recovered.retry_not_before is None, (
+        "Crash recovery must clear retry_not_before so the prompt is immediately eligible"
+    )

--- a/tests/test_fault_tolerance.py
+++ b/tests/test_fault_tolerance.py
@@ -119,6 +119,17 @@ def _auth_fail_result(error: str = "Error: Not authenticated. Please run 'claude
     )
 
 
+def _non_retryable_result(error: str = "Error: Claude Code cannot be launched inside another Claude Code session.") -> ExecutionResult:
+    return ExecutionResult(
+        success=False,
+        output="",
+        error=error,
+        execution_time=0.4,
+        is_non_retryable=True,
+        rate_limit_info=RateLimitInfo(is_rate_limited=False),
+    )
+
+
 def _success_result(output: str = "done") -> ExecutionResult:
     return ExecutionResult(
         success=True,
@@ -1831,3 +1842,51 @@ def test_network_loss_then_sigkill_then_restart_full_recovery(tmp_path, mock_ifa
     mgr2._process_queue_iteration()
 
     assert mgr2.state.total_processed == 1
+
+
+# ===========================================================================
+# Non-Retryable Error Scenarios (FT-086..087)
+# ===========================================================================
+
+
+def test_nested_session_error_unlimited_retries_fails_immediately(tmp_path, mocker):  # FT-086
+    """FT-086: nested-session error + max_retries=-1 → prompt reaches failed/ directory."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    mocker.patch.object(ClaudeCodeInterface, "test_connection", return_value=(True, "ok"))
+    mgr = QueueManager(storage_dir=str(tmp_path))
+
+    prompt = QueuedPrompt(id="ft086", content="task", max_retries=-1)
+    mgr.state = mgr.storage.load_queue_state()
+    mgr.state.add_prompt(prompt)
+    mgr.storage.save_queue_state(mgr.state)
+
+    mocker.patch.object(mgr.claude_interface, "execute_prompt", return_value=_non_retryable_result())
+    mgr._process_queue_iteration()
+
+    # Prompt must be in failed/ directory, not still in queue/
+    failed_files = list((tmp_path / "failed").glob("ft086-*.md"))
+    queue_files = list((tmp_path / "queue").glob("ft086-*.md"))
+    assert len(failed_files) == 1
+    assert len(queue_files) == 0
+
+
+def test_nested_session_error_not_picked_up_again(tmp_path, mocker):  # FT-087
+    """FT-087: After a non-retryable fail, the next queue iteration has nothing to execute."""
+    mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+    mocker.patch.object(ClaudeCodeInterface, "test_connection", return_value=(True, "ok"))
+    mgr = QueueManager(storage_dir=str(tmp_path))
+
+    prompt = QueuedPrompt(id="ft087", content="task", max_retries=-1)
+    mgr.state = mgr.storage.load_queue_state()
+    mgr.state.add_prompt(prompt)
+    mgr.storage.save_queue_state(mgr.state)
+
+    execute_mock = mocker.patch.object(
+        mgr.claude_interface, "execute_prompt", return_value=_non_retryable_result()
+    )
+
+    mgr._process_queue_iteration()  # First iteration: non-retryable fail
+    mgr._process_queue_iteration()  # Second iteration: nothing to execute
+
+    # execute_prompt must have been called exactly once
+    assert execute_mock.call_count == 1

--- a/tests/test_fault_tolerance.py
+++ b/tests/test_fault_tolerance.py
@@ -153,6 +153,9 @@ def iface():
     obj.claude_command = "claude"
     obj.timeout = 3600
     obj.skip_permissions = True
+    obj._current_process = None
+    obj._interrupted = False
+    obj._escalate_thread = None
     return obj
 
 
@@ -968,10 +971,20 @@ class TestKnownBugs:
 # ===========================================================================
 
 
+def _make_ft_mock_proc(returncode=0, stdout="done", stderr="", pid=99999):
+    """Create a mock Popen for fault-tolerance tests."""
+    proc = MagicMock()
+    proc.communicate.return_value = (stdout, stderr)
+    proc.returncode = returncode
+    proc.pid = pid
+    proc.wait.return_value = returncode
+    return proc
+
+
 def test_subprocess_nonzero_returncode_yields_failure_result(iface, mocker, tmp_path):  # FT-044
     """returncode=137 (SIGKILL) → success=False and is_rate_limited=False."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.return_value = MagicMock(returncode=137, stdout="", stderr="Killed")
+    mock_proc = _make_ft_mock_proc(returncode=137, stdout="", stderr="Killed")
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen", return_value=mock_proc)
 
     prompt = QueuedPrompt(
         id="t01aaaa", content="fix a bug", working_directory=str(tmp_path)
@@ -985,8 +998,10 @@ def test_subprocess_nonzero_returncode_yields_failure_result(iface, mocker, tmp_
 
 def test_subprocess_timeout_returns_timeout_failure(iface, mocker, tmp_path):  # FT-045
     """subprocess.TimeoutExpired is caught and returned as a failure, not re-raised."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+    mock_proc = _make_ft_mock_proc()
+    mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen", return_value=mock_proc)
+    mocker.patch.object(ClaudeCodeInterface, "_kill_proc_group")
 
     prompt = QueuedPrompt(
         id="t02aaaa", content="some task", working_directory=str(tmp_path)
@@ -1001,8 +1016,8 @@ def test_subprocess_timeout_returns_timeout_failure(iface, mocker, tmp_path):  #
 
 def test_subprocess_oserror_returns_failure_not_exception(iface, mocker, tmp_path):  # FT-046
     """OSError inside execute_prompt() is caught and returned as failure."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.side_effect = OSError("Connection reset by peer")
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen",
+                 side_effect=OSError("Connection reset by peer"))
 
     prompt = QueuedPrompt(
         id="t03aaaa", content="some task", working_directory=str(tmp_path)
@@ -1015,8 +1030,8 @@ def test_subprocess_oserror_returns_failure_not_exception(iface, mocker, tmp_pat
 
 def test_subprocess_generic_exception_returns_failure(iface, mocker, tmp_path):  # FT-047
     """RuntimeError inside execute_prompt() is caught via generic except clause."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.side_effect = RuntimeError("unexpected internal error")
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen",
+                 side_effect=RuntimeError("unexpected internal error"))
 
     prompt = QueuedPrompt(
         id="t04aaaa", content="task", working_directory=str(tmp_path)
@@ -1034,8 +1049,10 @@ def test_working_dir_restored_after_subprocess_timeout(iface, mocker, tmp_path):
 
     original_cwd = os.getcwd()
 
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+    mock_proc = _make_ft_mock_proc()
+    mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen", return_value=mock_proc)
+    mocker.patch.object(ClaudeCodeInterface, "_kill_proc_group")
 
     prompt = QueuedPrompt(
         id="t05aaaa", content="task", working_directory=str(work_dir)
@@ -1052,8 +1069,8 @@ def test_working_dir_restored_after_generic_exception(iface, mocker, tmp_path): 
 
     original_cwd = os.getcwd()
 
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.side_effect = RuntimeError("boom")
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen",
+                 side_effect=RuntimeError("boom"))
 
     prompt = QueuedPrompt(
         id="t06aaaa", content="task", working_directory=str(work_dir)
@@ -1065,8 +1082,8 @@ def test_working_dir_restored_after_generic_exception(iface, mocker, tmp_path): 
 
 def test_execute_prompt_returncode_137_not_rate_limited(iface, mocker, tmp_path):  # FT-050
     """SIGKILL exit (returncode 137) with 'Killed' in stdout is NOT rate-limited."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.return_value = MagicMock(returncode=137, stdout="Killed", stderr="")
+    mock_proc = _make_ft_mock_proc(returncode=137, stdout="Killed", stderr="")
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen", return_value=mock_proc)
 
     prompt = QueuedPrompt(
         id="t07aaaa", content="some work", working_directory=str(tmp_path)
@@ -1416,10 +1433,12 @@ class TestSIGKILLRecovery:
 
 def test_network_timeout_during_execution_returns_failure(iface, mocker, tmp_path):  # FT-067
     """Hung network call → TimeoutExpired → caught as failure, not re-raised."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.side_effect = subprocess.TimeoutExpired(
+    mock_proc = _make_ft_mock_proc()
+    mock_proc.communicate.side_effect = subprocess.TimeoutExpired(
         cmd=["claude", "--print", "..."], timeout=3600
     )
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen", return_value=mock_proc)
+    mocker.patch.object(ClaudeCodeInterface, "_kill_proc_group")
 
     prompt = QueuedPrompt(
         id="t24aaaa", content="fetch data", working_directory=str(tmp_path)
@@ -1433,12 +1452,12 @@ def test_network_timeout_during_execution_returns_failure(iface, mocker, tmp_pat
 
 def test_network_failure_nonzero_returncode_not_rate_limited(iface, mocker, tmp_path):  # FT-068
     """returncode=1 with DNS error in stderr → failure, not rate-limited."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.return_value = MagicMock(
+    mock_proc = _make_ft_mock_proc(
         returncode=1,
         stdout="",
         stderr="curl: (6) Could not resolve host: api.anthropic.com",
     )
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen", return_value=mock_proc)
 
     prompt = QueuedPrompt(
         id="t25aaaa", content="some task", working_directory=str(tmp_path)
@@ -1603,12 +1622,12 @@ def test_auth_error_text_not_classified_as_rate_limit(iface, error_string):  # F
 
 def test_auth_failure_returncode_nonzero_produces_failure_result(iface, mocker, tmp_path):  # FT-076
     """returncode=1 with auth error in stderr → success=False, is_rate_limited=False."""
-    mock_run = mocker.patch("claude_code_queue.claude_interface.subprocess.run")
-    mock_run.return_value = MagicMock(
+    mock_proc = _make_ft_mock_proc(
         returncode=1,
         stdout="",
         stderr="Error: Not authenticated. Please run 'claude login'.",
     )
+    mocker.patch("claude_code_queue.claude_interface.subprocess.Popen", return_value=mock_proc)
 
     prompt = QueuedPrompt(
         id="t33aaaa", content="task", working_directory=str(tmp_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,333 @@
+"""
+Tests for models.py — QueuedPrompt, RateLimitInfo, QueueState.
+"""
+
+import re
+from datetime import datetime, timedelta
+
+import pytest
+
+from claude_code_queue.models import (
+    ExecutionResult,
+    PromptStatus,
+    QueuedPrompt,
+    QueueState,
+    RateLimitInfo,
+)
+
+
+# ===========================================================================
+# QueuedPrompt — basic properties
+# ===========================================================================
+
+
+def test_prompt_id_is_8_hex_chars():  # MOD-001
+    """Auto-generated id is 8 characters from the uuid4 hex."""
+    p = QueuedPrompt(content="test")
+    assert len(p.id) == 8
+    assert all(c in "0123456789abcdef-" for c in p.id)
+
+
+def test_add_log_appends_timestamped_entry():  # MOD-002
+    """add_log() produces a line with [YYYY-MM-DD HH:MM:SS] prefix."""
+    p = QueuedPrompt(content="test")
+    p.add_log("step completed")
+    assert "step completed" in p.execution_log
+    assert re.search(
+        r"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]", p.execution_log
+    ), "Log entry must have [YYYY-MM-DD HH:MM:SS] timestamp"
+
+
+def test_add_log_is_cumulative():  # MOD-003
+    """Multiple add_log() calls accumulate all entries."""
+    p = QueuedPrompt(content="test")
+    p.add_log("first")
+    p.add_log("second")
+    p.add_log("third")
+    assert "first" in p.execution_log
+    assert "second" in p.execution_log
+    assert "third" in p.execution_log
+
+
+# ===========================================================================
+# QueuedPrompt — should_execute_now()
+# ===========================================================================
+
+
+def test_should_execute_now_queued_returns_true():  # MOD-004
+    """QUEUED status always passes the rate-limit check."""
+    p = QueuedPrompt(content="test", status=PromptStatus.QUEUED)
+    assert p.should_execute_now() is True
+
+
+def test_should_execute_now_executing_returns_true():  # MOD-005
+    """EXECUTING status also returns True — method is not a state-machine guard."""
+    p = QueuedPrompt(content="test", status=PromptStatus.EXECUTING)
+    assert p.should_execute_now() is True
+
+
+def test_should_execute_now_rate_limited_no_reset_time_returns_false():  # MOD-006
+    """RATE_LIMITED with no reset_time: we don't know the window — stay blocked."""
+    p = QueuedPrompt(content="test", status=PromptStatus.RATE_LIMITED)
+    p.reset_time = None
+    assert p.should_execute_now() is False
+
+
+def test_should_execute_now_rate_limited_past_reset_time_returns_true():  # MOD-007
+    """RATE_LIMITED whose reset window has passed: allow execution."""
+    p = QueuedPrompt(content="test", status=PromptStatus.RATE_LIMITED)
+    p.reset_time = datetime.now() - timedelta(minutes=5)
+    assert p.should_execute_now() is True
+
+
+def test_should_execute_now_rate_limited_future_reset_time_returns_false():  # MOD-008
+    """RATE_LIMITED with a future reset window: stay blocked."""
+    p = QueuedPrompt(content="test", status=PromptStatus.RATE_LIMITED)
+    p.reset_time = datetime.now() + timedelta(hours=2)
+    assert p.should_execute_now() is False
+
+
+# ===========================================================================
+# QueuedPrompt — can_retry()
+# ===========================================================================
+
+
+def test_can_retry_true_when_status_is_executing():  # MOD-009
+    """can_retry() must not gate on status when EXECUTING."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.EXECUTING,
+        retry_count=0,
+        max_retries=3,
+    )
+    assert prompt.can_retry() is True
+
+
+def test_can_retry_true_when_status_is_failed():  # MOD-010
+    """can_retry() works for FAILED status (FAILED is in the allowed list)."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.FAILED,
+        retry_count=0,
+        max_retries=3,
+    )
+    assert prompt.can_retry() is True
+
+
+def test_can_retry_false_when_retry_count_equals_max_retries():  # MOD-011
+    """Counter boundary: retry_count == max_retries → cannot retry."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.EXECUTING,
+        retry_count=3,
+        max_retries=3,
+    )
+    assert prompt.can_retry() is False
+
+
+def test_can_retry_false_when_retry_count_exceeds_max_retries():  # MOD-012
+    """Counter boundary: retry_count > max_retries → cannot retry."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.EXECUTING,
+        retry_count=5,
+        max_retries=3,
+    )
+    assert prompt.can_retry() is False
+
+
+def test_can_retry_unlimited_returns_true_at_any_count():  # MOD-013
+    """max_retries=-1 means unlimited; 999 < -1 must NOT be the check."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.EXECUTING,
+        retry_count=999,
+        max_retries=-1,
+    )
+    assert prompt.can_retry() is True
+
+
+def test_max_retries_minus_one_never_false():  # MOD-014
+    """Exhaustive: unlimited retries never returns False across 51 increments."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.EXECUTING,
+        max_retries=-1,
+    )
+    for count in range(51):
+        prompt.retry_count = count
+        assert prompt.can_retry() is True, (
+            f"can_retry() returned False at retry_count={count} with max_retries=-1"
+        )
+
+
+def test_can_retry_max_retries_zero():  # MOD-015
+    """Edge case: max_retries=0 means execute once and never retry."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.EXECUTING,
+        max_retries=0,
+        retry_count=0,
+    )
+    assert prompt.can_retry() is False
+
+
+def test_max_retries_3_total_attempts_semantics():  # MOD-016
+    """max_retries=3 allows retry_count 0,1,2 → True; at 3 → False."""
+    prompt = QueuedPrompt(
+        content="test", status=PromptStatus.EXECUTING, max_retries=3
+    )
+    for count in range(3):
+        prompt.retry_count = count
+        assert prompt.can_retry() is True, f"Expected True at retry_count={count}"
+    prompt.retry_count = 3
+    assert prompt.can_retry() is False
+
+
+def test_max_retries_1_means_no_retries():  # MOD-017
+    """max_retries=1: after the single attempt (retry_count incremented to 1) → False."""
+    prompt = QueuedPrompt(
+        content="test",
+        status=PromptStatus.EXECUTING,
+        max_retries=1,
+    )
+    prompt.retry_count = 1
+    assert prompt.can_retry() is False
+
+
+# ===========================================================================
+# QueueState — get_next_prompt, add/remove, stats
+# ===========================================================================
+
+
+def test_get_next_prompt_returns_lowest_priority_number():  # MOD-018
+    """get_next_prompt() picks the prompt with the numerically smallest priority."""
+    state = QueueState()
+    state.add_prompt(QueuedPrompt(content="high", priority=2))
+    state.add_prompt(QueuedPrompt(content="medium", priority=1))
+    state.add_prompt(QueuedPrompt(content="low", priority=0))
+    next_p = state.get_next_prompt()
+    assert next_p is not None
+    assert next_p.content == "low"
+    assert next_p.priority == 0
+
+
+def test_get_next_prompt_skips_non_queued():  # MOD-019
+    """EXECUTING and COMPLETED prompts are invisible to get_next_prompt()."""
+    state = QueueState()
+    state.add_prompt(
+        QueuedPrompt(content="executing", status=PromptStatus.EXECUTING)
+    )
+    state.add_prompt(
+        QueuedPrompt(content="completed", status=PromptStatus.COMPLETED)
+    )
+    state.add_prompt(QueuedPrompt(content="queued", status=PromptStatus.QUEUED))
+    next_p = state.get_next_prompt()
+    assert next_p is not None
+    assert next_p.content == "queued"
+
+
+def test_get_next_prompt_returns_none_when_empty():  # MOD-020
+    """Empty queue → get_next_prompt() returns None (no crash)."""
+    state = QueueState()
+    assert state.get_next_prompt() is None
+
+
+def test_get_next_prompt_skips_rate_limited():  # MOD-021
+    """A RATE_LIMITED prompt with a future reset_time must not be returned."""
+    state = QueueState()
+    p = QueuedPrompt(content="rate-limited", status=PromptStatus.RATE_LIMITED)
+    p.reset_time = datetime.now() + timedelta(hours=2)
+    state.add_prompt(p)
+    assert state.get_next_prompt() is None
+
+
+def test_get_next_prompt_promotes_rate_limited_when_reset_time_past():  # MOD-022
+    """get_next_prompt() promotes a RATE_LIMITED prompt whose reset window has closed.
+
+    The prompt's status is mutated to QUEUED in-place before being returned.
+    """
+    state = QueueState()
+    p = QueuedPrompt(
+        content="rate-limited-ready",
+        status=PromptStatus.RATE_LIMITED,
+        max_retries=3,
+        retry_count=1,
+    )
+    p.reset_time = datetime.now() - timedelta(minutes=5)
+    state.add_prompt(p)
+
+    result = state.get_next_prompt()
+    assert result is not None, "Should promote the rate-limited prompt"
+    assert result.status == PromptStatus.QUEUED, "Promotion sets status to QUEUED in-place"
+    assert result.id == p.id
+
+
+def test_add_prompt_increments_count():  # MOD-023
+    """add_prompt() appends exactly one item to state.prompts."""
+    state = QueueState()
+    assert len(state.prompts) == 0
+    state.add_prompt(QueuedPrompt(content="test"))
+    assert len(state.prompts) == 1
+
+
+def test_remove_prompt_decrements_count():  # MOD-024
+    """remove_prompt() eliminates the prompt with the matching id."""
+    state = QueueState()
+    p = QueuedPrompt(content="test")
+    state.add_prompt(p)
+    state.remove_prompt(p.id)
+    assert all(pr.id != p.id for pr in state.prompts)
+
+
+def test_get_stats_counts_by_status():  # MOD-025
+    """get_stats() returns counts nested under 'status_counts'.
+
+    - 'queued' counts active prompts in the in-memory list.
+    - 'completed' and 'failed' use the persistent counters
+      (total_processed / failed_count), NOT the prompt list.
+    - The stats dict is nested: stats['status_counts']['queued'], etc.
+    """
+    state = QueueState()
+    state.add_prompt(QueuedPrompt(content="q1", status=PromptStatus.QUEUED))
+    state.add_prompt(QueuedPrompt(content="q2", status=PromptStatus.QUEUED))
+    state.total_processed = 1
+    state.failed_count = 1
+
+    stats = state.get_stats()
+
+    assert stats["status_counts"]["queued"] == 2
+    assert stats["status_counts"]["completed"] == 1
+    assert stats["status_counts"]["failed"] == 1
+    assert stats["total_prompts"] == 2
+    assert stats["total_processed"] == 1
+    assert stats["failed_count"] == 1
+
+
+# ===========================================================================
+# RateLimitInfo — model-level tests
+# ===========================================================================
+
+
+def test_rate_limit_info_is_rate_limited_false_by_default():  # MOD-026
+    """RateLimitInfo() constructor defaults: not rate-limited, no reset time."""
+    info = RateLimitInfo()
+    assert info.is_rate_limited is False
+    assert info.reset_time is None
+
+
+def test_from_claude_response_rate_limit_detected():  # MOD-027
+    """RateLimitInfo.from_claude_response() detects the broad 'rate limit' phrase."""
+    info = RateLimitInfo.from_claude_response("rate limit hit on this account")
+    assert info.is_rate_limited is True
+    assert info.limit_message != ""
+    assert info.timestamp is not None
+
+
+def test_from_claude_response_normal_not_rate_limited():  # MOD-028
+    """from_claude_response() returns is_rate_limited=False for normal output."""
+    info = RateLimitInfo.from_claude_response(
+        "Successfully updated the authentication module."
+    )
+    assert info.is_rate_limited is False
+    assert info.reset_time is None

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -1,0 +1,492 @@
+"""
+Tests for queue_manager.py — QueueManager (ClaudeCodeInterface mocked).
+
+ClaudeCodeInterface.execute_prompt is patched for all execution tests.
+The manager fixture uses tmp_path so every test gets a fresh storage dir.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_code_queue.claude_interface import ClaudeCodeInterface
+from claude_code_queue.models import (
+    ExecutionResult,
+    PromptStatus,
+    QueuedPrompt,
+    QueueState,
+    RateLimitInfo,
+)
+from claude_code_queue.queue_manager import QueueManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _success_result(output: str = "done") -> ExecutionResult:
+    return ExecutionResult(success=True, output=output, error="", execution_time=0.1)
+
+
+def _fail_result(error: str = "error") -> ExecutionResult:
+    return ExecutionResult(success=False, output="", error=error, execution_time=0.1)
+
+
+def _rate_limit_result(reset_time=None) -> ExecutionResult:
+    return ExecutionResult(
+        success=False,
+        output="usage limit reached",
+        error="",
+        rate_limit_info=RateLimitInfo(is_rate_limited=True, reset_time=reset_time),
+        execution_time=0.1,
+    )
+
+
+# ===========================================================================
+# Rate-Limit Result Processing
+# ===========================================================================
+
+
+def test_was_already_rate_limited_uses_rate_limited_at(manager):  # QMG-001
+    """_process_execution_result() must use prompt.rate_limited_at (not
+    prompt.status) to decide whether to increment rate_limited_count.
+    """
+    prompt = QueuedPrompt(content="task", status=PromptStatus.EXECUTING)
+    prompt.rate_limited_at = datetime.now() - timedelta(minutes=10)
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager.state.rate_limited_count = 1
+
+    rl_result = _rate_limit_result()
+    manager._process_execution_result(prompt, rl_result)
+
+    assert manager.state.rate_limited_count == 1, (
+        "rate_limited_count must NOT be incremented when the prompt was already "
+        "rate-limited (rate_limited_at is set)"
+    )
+
+
+def test_reset_time_assigned_from_rate_limit_info(manager):  # QMG-002
+    """prompt.reset_time must be set from rate_limit_info.reset_time."""
+    expected_reset = datetime(2025, 6, 1, 15, 0, 0)
+    prompt = QueuedPrompt(content="task", status=PromptStatus.EXECUTING)
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+
+    rl_result = _rate_limit_result(reset_time=expected_reset)
+    manager._process_execution_result(prompt, rl_result)
+
+    assert prompt.reset_time is not None, "reset_time must be set on the prompt"
+    delta = abs((prompt.reset_time - expected_reset).total_seconds())
+    assert delta < 1, f"reset_time drifted by {delta:.3f}s"
+    assert prompt.reset_time.tzinfo is None, "reset_time must be stored as naive"
+
+
+def test_check_rate_limited_uses_reset_time_when_past(manager):  # QMG-003
+    """When reset_time is in the past, re-queue immediately — even if
+    rate_limited_at was only 30 seconds ago (inside the 5-min heuristic window).
+    """
+    prompt = QueuedPrompt(content="task", status=PromptStatus.RATE_LIMITED, max_retries=3)
+    prompt.rate_limited_at = datetime.now() - timedelta(seconds=30)
+    prompt.reset_time = datetime.now() - timedelta(minutes=1)
+    prompt.retry_count = 0
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager._check_rate_limited_prompts()
+
+    assert prompt.status == PromptStatus.QUEUED, (
+        "Prompt with a past reset_time must be re-queued regardless of "
+        "how recently it was rate-limited"
+    )
+
+
+def test_check_rate_limited_stays_rate_limited_when_reset_time_future(manager):  # QMG-004
+    """When reset_time is known but future, the prompt must NOT be re-queued
+    by the 5-minute heuristic fallback.
+    """
+    prompt = QueuedPrompt(content="task", status=PromptStatus.RATE_LIMITED, max_retries=3)
+    prompt.rate_limited_at = datetime.now() - timedelta(minutes=6)
+    prompt.reset_time = datetime.now() + timedelta(hours=2)
+    prompt.retry_count = 0
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager._check_rate_limited_prompts()
+
+    assert prompt.status == PromptStatus.RATE_LIMITED, (
+        "Prompt with a future reset_time must stay RATE_LIMITED "
+        "(the 5-min heuristic must not fire when reset_time is known)"
+    )
+
+
+def test_check_rate_limited_falls_back_to_5min_heuristic_when_no_reset_time(manager):  # QMG-005
+    """When no reset_time is set and rate_limited_at > 5 min ago, re-queue."""
+    prompt = QueuedPrompt(content="task", status=PromptStatus.RATE_LIMITED, max_retries=3)
+    prompt.rate_limited_at = datetime.now() - timedelta(minutes=6)
+    prompt.reset_time = None
+    prompt.retry_count = 0
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager._check_rate_limited_prompts()
+
+    assert prompt.status == PromptStatus.QUEUED
+
+
+def test_state_saved_after_rate_limit_check_exhausts_retries(manager):  # QMG-006
+    """save_queue_state() is called even when no prompt is executed.
+
+    Scenario: a rate-limited prompt exhausts its retries during
+    _check_rate_limited_prompts() → becomes FAILED → state must be persisted.
+    """
+    state = manager.storage.load_queue_state()
+    prompt = QueuedPrompt(
+        content="task", status=PromptStatus.RATE_LIMITED, max_retries=1
+    )
+    prompt.rate_limited_at = datetime.now() - timedelta(minutes=10)
+    prompt.retry_count = 1
+    state.add_prompt(prompt)
+    manager.storage.save_queue_state(state)
+
+    with patch.object(
+        manager.storage, "save_queue_state", wraps=manager.storage.save_queue_state
+    ) as mock_save:
+        manager.state = None
+        manager._process_queue_iteration()
+        mock_save.assert_called()
+
+    failed_files = list(manager.storage.failed_dir.glob("*.md"))
+    assert len(failed_files) == 1, (
+        f"Expected 1 failed file, found {len(failed_files)}: {failed_files}"
+    )
+
+
+def test_check_rate_limited_fails_prompt_when_retries_exhausted(manager):  # QMG-007
+    """When retries are exhausted during the 5-min check, status → FAILED."""
+    prompt = QueuedPrompt(
+        content="task", status=PromptStatus.RATE_LIMITED, max_retries=1
+    )
+    prompt.rate_limited_at = datetime.now() - timedelta(minutes=10)
+    prompt.reset_time = None
+    prompt.retry_count = 1
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager._check_rate_limited_prompts()
+
+    assert prompt.status == PromptStatus.FAILED, (
+        f"Expected FAILED when retries exhausted, got {prompt.status}"
+    )
+
+
+# ===========================================================================
+# Execution Lifecycle
+# ===========================================================================
+
+
+def test_start_processes_queued_prompt(manager):  # QMG-008
+    """A single QUEUED prompt with a mocked successful result moves to COMPLETED."""
+    success = _success_result("All done")
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=success):
+        state = manager.storage.load_queue_state()
+        state.add_prompt(QueuedPrompt(content="test task"))
+        manager.storage.save_queue_state(state)
+        manager._process_queue_iteration()
+        completed = list(manager.storage.completed_dir.glob("*.md"))
+        assert len(completed) == 1
+
+
+def test_priority_order_respected(manager):  # QMG-009
+    """The prompt with the lowest priority number is executed first."""
+    executed_ids = []
+
+    def fake_execute(prompt):
+        executed_ids.append(prompt.id)
+        return _success_result()
+
+    state = manager.storage.load_queue_state()
+    p_low = QueuedPrompt(content="low priority", priority=5)
+    p_high = QueuedPrompt(content="high priority", priority=1)
+    state.add_prompt(p_low)
+    state.add_prompt(p_high)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    with patch.object(manager.claude_interface, "execute_prompt", side_effect=fake_execute):
+        manager._process_queue_iteration()
+
+    assert len(executed_ids) >= 1, "At least one prompt must have been executed"
+    assert executed_ids[0] == p_high.id, (
+        f"Expected high-priority prompt ({p_high.id}) first, got {executed_ids[0]}"
+    )
+
+
+def test_failed_prompt_retried_up_to_max_retries(manager):  # QMG-010
+    """A prompt that always fails is retried up to max_retries times then FAILED."""
+    fail = _fail_result("build failed")
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="failing task", max_retries=2)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=fail):
+        for _ in range(5):
+            manager.state = None
+            manager._process_queue_iteration()
+
+    failed_files = list(manager.storage.failed_dir.glob("*.md"))
+    assert len(failed_files) == 1, (
+        f"Expected 1 failed file after exhausting retries, got {len(failed_files)}"
+    )
+
+
+def test_rate_limited_prompt_re_queued_after_reset_time(manager):  # QMG-011
+    """A rate-limited prompt with a past reset_time is re-queued and then completes."""
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="rate limited task", max_retries=3)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+
+    past_reset = datetime.now() - timedelta(minutes=1)
+    rl_result = _rate_limit_result(reset_time=past_reset)
+
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=rl_result):
+        manager.state = None
+        manager._process_queue_iteration()
+
+    state_after_rl = manager.storage.load_queue_state()
+    rl_prompts = [pr for pr in state_after_rl.prompts if pr.status == PromptStatus.RATE_LIMITED]
+    assert len(rl_prompts) == 1, "Prompt should be RATE_LIMITED after first iteration"
+    assert rl_prompts[0].reset_time is not None, "reset_time must have been assigned"
+    assert rl_prompts[0].reset_time <= datetime.now(), "reset_time should be in the past"
+
+    success = _success_result("done")
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=success):
+        manager.state = None
+        manager._process_queue_iteration()
+
+    completed = list(manager.storage.completed_dir.glob("*.md"))
+    assert len(completed) == 1, "Prompt should complete after re-queue and successful execution"
+
+
+def test_cancel_removes_prompt_from_execution(manager):  # QMG-012
+    """remove_prompt() cancels a QUEUED prompt; it disappears from the active queue."""
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="to be cancelled")
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+
+    result = manager.remove_prompt(p.id)
+    assert result is True
+
+    reloaded = manager.storage.load_queue_state()
+    remaining = [pr for pr in reloaded.prompts if pr.id == p.id]
+    assert len(remaining) == 0 or remaining[0].status == PromptStatus.CANCELLED
+
+
+def test_log_shows_infinity_for_max_retries_minus_one(manager):  # QMG-013
+    """When max_retries=-1, the execution log must display '∞' rather than '-1'."""
+    fail = _fail_result("err")
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="unlimited retries", max_retries=-1)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=fail):
+        manager._process_queue_iteration()
+
+    executed_prompt = next(
+        (pr for pr in manager.state.prompts if pr.id == p.id), None
+    )
+    assert executed_prompt is not None, "Prompt must be in manager.state after iteration"
+    assert "∞" in executed_prompt.execution_log, (
+        f"Expected '∞' in execution_log for max_retries=-1, got:\n{executed_prompt.execution_log}"
+    )
+
+
+def test_get_status_returns_correct_counts(manager):  # QMG-014
+    """get_status() returns the live QueueState with the correct prompt list."""
+    state = manager.storage.load_queue_state()
+    state.add_prompt(QueuedPrompt(content="task1"))
+    state.add_prompt(QueuedPrompt(content="task2"))
+    manager.storage.save_queue_state(state)
+
+    status = manager.get_status()
+    queued = [p for p in status.prompts if p.status == PromptStatus.QUEUED]
+    assert len(queued) == 2
+
+
+def test_executing_to_queued_retry_after_failure(manager):  # QMG-015
+    """After a failed execution with retries remaining, prompt transitions
+    EXECUTING → QUEUED (not EXECUTING → FAILED).
+    """
+    fail = _fail_result("transient error")
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="retry me", max_retries=3, retry_count=0)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=fail):
+        manager._process_queue_iteration()
+
+    updated = next(
+        (pr for pr in manager.state.prompts if pr.id == p.id), None
+    )
+    assert updated is not None, "Prompt must still be in manager.state"
+    assert updated.status == PromptStatus.QUEUED, (
+        f"Expected QUEUED after first failure, got {updated.status}"
+    )
+    assert updated.retry_count == 1, (
+        f"Expected retry_count=1 after one failure, got {updated.retry_count}"
+    )
+
+
+def test_timezone_aware_reset_time_stored_as_naive(manager):  # QMG-016
+    """Timezone-aware reset_time from rate_limit_info is stripped of tzinfo."""
+    aware_time = datetime(2025, 6, 1, 15, 0, 0, tzinfo=timezone.utc)
+    rl_result = ExecutionResult(
+        success=False,
+        output="usage limit reached",
+        error="",
+        rate_limit_info=RateLimitInfo(is_rate_limited=True, reset_time=aware_time),
+        execution_time=0.1,
+    )
+    prompt = QueuedPrompt(content="task", status=PromptStatus.EXECUTING)
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+
+    manager._process_execution_result(prompt, rl_result)
+
+    assert prompt.reset_time is not None, "reset_time must be assigned"
+    assert prompt.reset_time.tzinfo is None, (
+        "reset_time must be stored as naive (no tzinfo)"
+    )
+
+
+def test_cancel_executing_prompt_returns_false(manager):  # QMG-017
+    """remove_prompt() refuses to cancel a currently-executing prompt."""
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="running now", status=PromptStatus.EXECUTING)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = state
+
+    result = manager.remove_prompt(p.id)
+    assert result is False
+
+
+def test_shutdown_requeues_executing_prompts(manager):  # QMG-018
+    """_shutdown() transitions EXECUTING prompts back to QUEUED for the next run."""
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="in flight", status=PromptStatus.EXECUTING)
+    state.add_prompt(p)
+    manager.state = state
+
+    manager._shutdown()
+
+    reloaded = manager.storage.load_queue_state()
+    prompt_after = next(
+        (pr for pr in reloaded.prompts if pr.id == p.id), None
+    )
+    assert prompt_after is not None, "Prompt must survive shutdown"
+    assert prompt_after.status == PromptStatus.QUEUED, (
+        f"Expected QUEUED after shutdown, got {prompt_after.status}"
+    )
+
+
+def test_process_execution_result_assigns_last_processed(manager):  # QMG-019
+    """After any execution (success or failure), state.last_processed is updated."""
+    manager.state = QueueState()
+    prompt = QueuedPrompt(content="task")
+    manager.state.add_prompt(prompt)
+    assert manager.state.last_processed is None
+
+    success = _success_result("ok")
+    manager._process_execution_result(prompt, success)
+
+    assert manager.state.last_processed is not None
+    delta = abs((manager.state.last_processed - datetime.now()).total_seconds())
+    assert delta < 5, f"last_processed is {delta:.1f}s from now; expected < 5s"
+
+
+# ===========================================================================
+# Prompt Management
+# ===========================================================================
+
+
+def test_remove_nonexistent_prompt_returns_false(manager):  # QMG-020
+    """remove_prompt() with an unknown id returns False (not raises)."""
+    manager.state = manager.storage.load_queue_state()
+    result = manager.remove_prompt("doesnotexist")
+    assert result is False
+
+
+def test_iteration_preserves_in_memory_counters_across_reload(manager):  # QMG-021
+    """_process_queue_iteration() must not regress in-memory counters that are
+    ahead of the on-disk value when reloading state.
+    """
+    state = manager.storage.load_queue_state()
+    state.total_processed = 3
+    manager.storage.save_queue_state(state)
+
+    manager.state = state
+    manager.state.total_processed = 7
+
+    manager._process_queue_iteration()
+
+    assert manager.state.total_processed == 7, (
+        "In-memory counter must not be overwritten by stale on-disk value"
+    )
+
+
+def test_check_rate_limited_stays_rate_limited_under_5min(manager):  # QMG-022
+    """4 minutes 59 seconds is not long enough — prompt stays RATE_LIMITED."""
+    prompt = QueuedPrompt(
+        content="task", status=PromptStatus.RATE_LIMITED, max_retries=3
+    )
+    prompt.rate_limited_at = datetime.now() - timedelta(seconds=299)
+    prompt.reset_time = None
+    prompt.retry_count = 0
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager._check_rate_limited_prompts()
+
+    assert prompt.status == PromptStatus.RATE_LIMITED
+
+
+def test_check_rate_limited_requeues_just_over_5min(manager):  # QMG-023
+    """5 minutes 1 second is enough — prompt re-queues via the heuristic."""
+    prompt = QueuedPrompt(
+        content="task", status=PromptStatus.RATE_LIMITED, max_retries=3
+    )
+    prompt.rate_limited_at = datetime.now() - timedelta(seconds=301)
+    prompt.reset_time = None
+    prompt.retry_count = 0
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager._check_rate_limited_prompts()
+
+    assert prompt.status == PromptStatus.QUEUED
+
+
+def test_manager_add_prompt_saves_to_disk(manager):  # QMG-024
+    """QueueManager.add_prompt() saves the prompt to storage so it survives reload."""
+    p = QueuedPrompt(content="new task via manager")
+    manager.state = None
+
+    result = manager.add_prompt(p)
+    assert result is True
+
+    reloaded = manager.storage.load_queue_state()
+    ids = [pr.id for pr in reloaded.prompts]
+    assert p.id in ids, (
+        f"Prompt {p.id!r} not found in reloaded state. Found ids: {ids}"
+    )

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -6,7 +6,7 @@ The manager fixture uses tmp_path so every test gets a fresh storage dir.
 """
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
 
@@ -236,7 +236,11 @@ def test_priority_order_respected(manager):  # QMG-009
 
 
 def test_failed_prompt_retried_up_to_max_retries(manager):  # QMG-010
-    """A prompt that always fails is retried up to max_retries times then FAILED."""
+    """A prompt that always fails is retried up to max_retries times then FAILED.
+
+    After Fix 3, each failure sets retry_not_before into the future. We clear
+    it between iterations to simulate the passage of time.
+    """
     fail = _fail_result("build failed")
     state = manager.storage.load_queue_state()
     p = QueuedPrompt(content="failing task", max_retries=2)
@@ -247,6 +251,12 @@ def test_failed_prompt_retried_up_to_max_retries(manager):  # QMG-010
         for _ in range(5):
             manager.state = None
             manager._process_queue_iteration()
+            # Simulate passage of time past retry_not_before.
+            if manager.state:
+                for pr in manager.state.prompts:
+                    if pr.retry_not_before is not None:
+                        pr.retry_not_before = datetime.now() - timedelta(seconds=1)
+                manager.storage.save_queue_state(manager.state)
 
     failed_files = list(manager.storage.failed_dir.glob("*.md"))
     assert len(failed_files) == 1, (
@@ -568,3 +578,145 @@ def test_ordinary_failure_still_retries(manager, mocker):  # QMG-NR-004
 
     assert prompt.status == PromptStatus.QUEUED  # retried, not failed
     assert prompt.retry_count == 1
+
+
+# ===========================================================================
+# Fix 3 — Retry Backoff for Generic Failures
+# ===========================================================================
+
+
+def test_generic_failure_sets_retry_not_before(manager):  # QMG-025
+    """After a generic (non-rate-limited) failure with retries remaining,
+    prompt.retry_not_before is set to a future datetime.
+    """
+    fail = _fail_result("transient error")
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="retry me", max_retries=3, retry_count=0)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=fail):
+        manager._process_queue_iteration()
+
+    updated = next(pr for pr in manager.state.prompts if pr.id == p.id)
+    assert updated.retry_not_before is not None
+    assert updated.retry_not_before > datetime.now()
+
+
+def test_prompt_with_future_retry_not_before_is_skipped(manager):  # QMG-026
+    """A QUEUED prompt whose retry_not_before is in the future must not be
+    selected for execution.
+    """
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="not yet", max_retries=3, retry_count=1)
+    p.retry_not_before = datetime.now() + timedelta(minutes=5)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    with patch.object(manager.claude_interface, "execute_prompt") as mock_exec:
+        did_work = manager._process_queue_iteration()
+
+    assert did_work is False
+    mock_exec.assert_not_called()
+
+
+def test_prompt_with_past_retry_not_before_is_eligible(manager):  # QMG-027
+    """A QUEUED prompt whose retry_not_before is in the past must be eligible
+    for execution.
+    """
+    success = _success_result()
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="ready now", max_retries=3, retry_count=1)
+    p.retry_not_before = datetime.now() - timedelta(seconds=1)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=success):
+        did_work = manager._process_queue_iteration()
+
+    assert did_work is True
+
+
+def test_retry_not_before_not_set_on_final_failure(manager):  # QMG-028
+    """When max retries are exhausted, the prompt becomes FAILED, not QUEUED.
+    retry_not_before is irrelevant for FAILED prompts.
+    """
+    fail = _fail_result("final")
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="exhausted", max_retries=1, retry_count=1)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    with patch.object(manager.claude_interface, "execute_prompt", return_value=fail):
+        manager._process_queue_iteration()
+
+    updated = next(pr for pr in manager.state.prompts if pr.id == p.id)
+    assert updated.status == PromptStatus.FAILED
+
+
+def test_retry_not_before_persists_through_reload(manager):  # QMG-029
+    """retry_not_before written to YAML frontmatter survives a state reload."""
+    future = datetime.now() + timedelta(minutes=10)
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="persist test", max_retries=3, retry_count=1)
+    p.retry_not_before = future
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+
+    reloaded = manager.storage.load_queue_state()
+    reloaded_prompt = next(pr for pr in reloaded.prompts if pr.id == p.id)
+    assert reloaded_prompt.retry_not_before is not None
+    delta = abs((reloaded_prompt.retry_not_before - future).total_seconds())
+    assert delta < 5, f"Persisted retry_not_before drifted by {delta:.3f}s"
+    assert reloaded_prompt.retry_not_before.tzinfo is None
+
+
+def test_retry_not_before_does_not_affect_rate_limited_prompts(manager):  # QMG-030
+    """A RATE_LIMITED prompt must be handled by reset_time / rate_limited_at,
+    not by retry_not_before. The two mechanisms must not interfere.
+    """
+    prompt = QueuedPrompt(
+        content="rate limited", status=PromptStatus.RATE_LIMITED, max_retries=3
+    )
+    prompt.rate_limited_at = datetime.now() - timedelta(minutes=6)
+    prompt.reset_time = None
+    prompt.retry_not_before = datetime.now() + timedelta(hours=1)  # future, but irrelevant
+    prompt.retry_count = 0
+
+    manager.state = QueueState()
+    manager.state.add_prompt(prompt)
+    manager._check_rate_limited_prompts()
+
+    # 5-min heuristic should fire (rate_limited_at > 5min ago, no reset_time)
+    assert prompt.status == PromptStatus.QUEUED
+    assert prompt.should_execute_now() is True, (
+        "Re-queued rate-limited prompt must be immediately selectable; "
+        "retry_not_before must be cleared or already past"
+    )
+
+
+def test_cooldown_prompt_does_not_print_no_prompts_in_queue(manager, capsys):  # QMG-031
+    """When a prompt is in retry_not_before cooldown and no other prompts exist,
+    the iteration must NOT print "No prompts in queue". It must print a cooldown
+    message that includes the remaining wait time.
+    """
+    state = manager.storage.load_queue_state()
+    p = QueuedPrompt(content="cooling down", max_retries=3, retry_count=1)
+    p.retry_not_before = datetime.now() + timedelta(minutes=5)
+    state.add_prompt(p)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    manager._process_queue_iteration()
+
+    captured = capsys.readouterr()
+    assert "No prompts in queue" not in captured.out, (
+        "Must not print 'No prompts in queue' when a prompt is in cooldown"
+    )
+    assert "retry cooldown" in captured.out.lower(), (
+        "Must print a message indicating the prompt is in retry cooldown"
+    )

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -44,6 +44,16 @@ def _rate_limit_result(reset_time=None) -> ExecutionResult:
     )
 
 
+def _non_retryable_result(error: str = "Error: Claude Code cannot be launched inside another Claude Code session.") -> ExecutionResult:
+    return ExecutionResult(
+        success=False,
+        output="",
+        error=error,
+        execution_time=0.4,
+        is_non_retryable=True,
+    )
+
+
 # ===========================================================================
 # Rate-Limit Result Processing
 # ===========================================================================
@@ -490,3 +500,71 @@ def test_manager_add_prompt_saves_to_disk(manager):  # QMG-024
     assert p.id in ids, (
         f"Prompt {p.id!r} not found in reloaded state. Found ids: {ids}"
     )
+
+
+# ===========================================================================
+# Non-Retryable Error Handling
+# ===========================================================================
+
+
+def test_non_retryable_error_immediately_fails_with_unlimited_retries(manager, mocker):  # QMG-NR-001
+    """A non-retryable error marks the prompt FAILED immediately even when max_retries=-1."""
+    prompt = QueuedPrompt(id="test01", content="task", max_retries=-1)
+    manager.state = manager.storage.load_queue_state()
+    manager.state.add_prompt(prompt)
+
+    mocker.patch.object(
+        manager.claude_interface, "execute_prompt", return_value=_non_retryable_result()
+    )
+    manager._execute_prompt(prompt)
+
+    assert prompt.status == PromptStatus.FAILED
+    assert prompt.retry_count == 0  # retry_count not incremented for non-retryable errors
+    assert manager.state.failed_count == 1
+
+
+def test_non_retryable_error_immediately_fails_with_finite_retries(manager, mocker):  # QMG-NR-002
+    """A non-retryable error fails the prompt immediately even when retries remain."""
+    prompt = QueuedPrompt(id="test02", content="task", max_retries=3)
+    manager.state = manager.storage.load_queue_state()
+    manager.state.add_prompt(prompt)
+
+    mocker.patch.object(
+        manager.claude_interface, "execute_prompt", return_value=_non_retryable_result()
+    )
+    manager._execute_prompt(prompt)
+
+    assert prompt.status == PromptStatus.FAILED
+    # retry_count not consumed: if re-queued manually, full budget is available
+    assert prompt.retry_count == 0
+    assert manager.state.failed_count == 1
+
+
+def test_non_retryable_error_logged_as_non_retryable(manager, mocker):  # QMG-NR-003
+    """Execution log mentions non-retryable so operator knows why no retry occurred."""
+    prompt = QueuedPrompt(id="test03", content="task", max_retries=-1)
+    manager.state = manager.storage.load_queue_state()
+    manager.state.add_prompt(prompt)
+
+    mocker.patch.object(
+        manager.claude_interface, "execute_prompt", return_value=_non_retryable_result()
+    )
+    manager._execute_prompt(prompt)
+
+    assert "non-retryable" in prompt.execution_log.lower()
+
+
+def test_ordinary_failure_still_retries(manager, mocker):  # QMG-NR-004
+    """A normal (retryable) failure still uses the can_retry() path."""
+    prompt = QueuedPrompt(id="test04", content="task", max_retries=3)
+    manager.state = manager.storage.load_queue_state()
+    manager.state.add_prompt(prompt)
+
+    mocker.patch.object(
+        manager.claude_interface, "execute_prompt",
+        return_value=ExecutionResult(success=False, output="", error="transient", execution_time=0.1)
+    )
+    manager._execute_prompt(prompt)
+
+    assert prompt.status == PromptStatus.QUEUED  # retried, not failed
+    assert prompt.retry_count == 1

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -5,6 +5,8 @@ ClaudeCodeInterface.execute_prompt is patched for all execution tests.
 The manager fixture uses tmp_path so every test gets a fresh storage dir.
 """
 
+import signal
+import threading
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch, PropertyMock
 
@@ -719,4 +721,114 @@ def test_cooldown_prompt_does_not_print_no_prompts_in_queue(manager, capsys):  #
     )
     assert "retry cooldown" in captured.out.lower(), (
         "Must print a message indicating the prompt is in retry cooldown"
+    )
+
+
+# ===========================================================================
+# Interrupt / Signal Handling (QMG-INT)
+# ===========================================================================
+
+
+def test_signal_handler_calls_kill_current_before_stop(manager):  # QMG-INT-001
+    """_signal_handler() calls kill_current() before stop() (verify ordering)."""
+    call_log = []
+
+    manager.claude_interface.kill_current = MagicMock(
+        side_effect=lambda: call_log.append("kill_current")
+    )
+    original_stop = manager.stop
+    manager.stop = MagicMock(
+        side_effect=lambda: (call_log.append("stop"), original_stop())
+    )
+
+    manager._signal_handler(signal.SIGINT, None)
+
+    assert call_log == ["kill_current", "stop"], (
+        f"Expected kill_current before stop, got {call_log}"
+    )
+
+
+def test_keyboard_interrupt_bypasses_process_execution_result(manager, mocker):  # QMG-INT-002
+    """When execute_prompt() raises KeyboardInterrupt, _process_execution_result()
+    is bypassed and the prompt remains EXECUTING.
+    """
+    prompt = QueuedPrompt(id="test01", content="task")
+    manager.state = manager.storage.load_queue_state()
+    manager.state.add_prompt(prompt)
+
+    mocker.patch.object(
+        manager.claude_interface, "execute_prompt",
+        side_effect=KeyboardInterrupt
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        manager._execute_prompt(prompt)
+
+    assert prompt.status == PromptStatus.EXECUTING
+
+
+def test_end_to_end_signal_shutdown_reverts_prompt(manager, mocker):  # QMG-INT-003
+    """End-to-end: signal → kill_current → KeyboardInterrupt → _shutdown() → QUEUED.
+
+    WARNING: This test exercises true cross-thread access to _current_process
+    and _interrupted WITHOUT locks.  This is safe under the GIL (CPython) but
+    will race under free-threaded Python (PEP 703, --disable-gil).  If
+    free-threaded builds become a target, the production code must add
+    synchronization (not just this test).
+    """
+    prompt = QueuedPrompt(id="test02", content="task")
+    state = manager.storage.load_queue_state()
+    state.add_prompt(prompt)
+    manager.storage.save_queue_state(state)
+    manager.state = None
+
+    # Event to synchronize the mock communicate() with the signal handler
+    communicate_started = threading.Event()
+    signal_sent = threading.Event()
+
+    def mock_communicate(timeout=None):
+        communicate_started.set()
+        signal_sent.wait(timeout=5)
+        # After signal handler ran, _interrupted should be True
+        return ("output", "")
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 99999
+    mock_proc.communicate.side_effect = mock_communicate
+    mock_proc.returncode = 0
+    mock_proc.wait.return_value = 0
+
+    execution_error = []
+
+    def run_iteration():
+        try:
+            manager._process_queue_iteration()
+        except KeyboardInterrupt:
+            execution_error.append("KeyboardInterrupt")
+
+    mocker.patch("subprocess.Popen", return_value=mock_proc)
+    mocker.patch.object(ClaudeCodeInterface, "_kill_proc_group", return_value=True)
+
+    worker = threading.Thread(target=run_iteration)
+    worker.start()
+
+    # Wait for communicate() to start, then send signal
+    assert communicate_started.wait(timeout=5), "communicate() did not start"
+    manager._signal_handler(signal.SIGINT, None)
+    signal_sent.set()
+
+    worker.join(timeout=5)
+    assert not worker.is_alive(), "Worker thread did not finish"
+    assert "KeyboardInterrupt" in execution_error
+
+    # Verify _shutdown() reverts prompt to QUEUED
+    manager._shutdown()
+
+    reloaded = manager.storage.load_queue_state()
+    prompt_after = next(
+        (pr for pr in reloaded.prompts if pr.id == "test02"), None
+    )
+    assert prompt_after is not None, "Prompt must survive shutdown"
+    assert prompt_after.status == PromptStatus.QUEUED, (
+        f"Expected QUEUED after shutdown, got {prompt_after.status}"
     )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,863 @@
+"""
+Tests for storage.py — MarkdownPromptParser, QueueStorage.
+"""
+
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from claude_code_queue.models import (
+    PromptStatus,
+    QueuedPrompt,
+    QueueState,
+)
+from claude_code_queue.storage import MarkdownPromptParser, QueueStorage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_FRONTMATTER = (
+    "---\n"
+    "priority: 0\n"
+    "working_directory: .\n"
+    "max_retries: 3\n"
+    "status: queued\n"
+    "retry_count: 0\n"
+    "created_at: 2025-01-01T00:00:00\n"
+    "---\n\n"
+)
+
+
+def _make_executing_file(queue_dir: Path, prompt_id: str, title: str, content: str) -> Path:
+    """Write a .executing.md file as if a previous run crashed mid-execution."""
+    path = queue_dir / f"{prompt_id}-{title}.executing.md"
+    path.write_text(
+        f"---\n"
+        f"priority: 0\n"
+        f"working_directory: .\n"
+        f"max_retries: 3\n"
+        f"status: executing\n"
+        f"retry_count: 0\n"
+        f"created_at: 2025-01-01T00:00:00\n"
+        f"---\n\n"
+        f"{content}"
+    )
+    return path
+
+
+# ===========================================================================
+# Orphan Recovery
+# ===========================================================================
+
+
+def test_queued_transition_removes_stale_executing_file(tmp_path):  # STO-001
+    """Saving a QUEUED prompt must delete any stale .executing.md file."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(id="abc12345", content="test prompt")
+
+    stale_path = storage.queue_dir / "abc12345-test-prompt.executing.md"
+    stale_path.write_text(MINIMAL_FRONTMATTER + "test prompt")
+    assert stale_path.exists(), "Stale file must exist before the action"
+
+    prompt.status = PromptStatus.QUEUED
+    storage._save_single_prompt(prompt)
+
+    assert not stale_path.exists(), "Stale .executing.md was not removed"
+    regular_files = list(storage.queue_dir.glob("abc12345-*.md"))
+    non_executing = [f for f in regular_files if not f.name.endswith(".executing.md")]
+    assert len(non_executing) == 1, (
+        f"Expected one plain .md for the prompt, found: {regular_files}"
+    )
+    executing_files = list(storage.queue_dir.glob("abc12345-*.executing.md"))
+    assert len(executing_files) == 0, "No .executing.md should remain"
+
+
+def test_load_executing_file_returns_queued_status(tmp_path):  # STO-002
+    """.executing.md files must be recovered as QUEUED (at-least-once semantics)."""
+    storage = QueueStorage(str(tmp_path))
+    _make_executing_file(storage.queue_dir, "abc12345", "my-prompt", "my prompt content")
+
+    state = storage.load_queue_state()
+
+    assert len(state.prompts) == 1
+    assert state.prompts[0].status == PromptStatus.QUEUED
+    assert state.prompts[0].id == "abc12345"
+
+
+def test_load_executing_file_adds_recovery_log(tmp_path):  # STO-003
+    """Recovered prompts must have a log entry noting the recovery."""
+    storage = QueueStorage(str(tmp_path))
+    _make_executing_file(storage.queue_dir, "abc12345", "my-prompt", "my prompt content")
+
+    state = storage.load_queue_state()
+
+    assert len(state.prompts) == 1
+    log = state.prompts[0].execution_log
+    assert "recovered" in log.lower(), (
+        f"Expected 'Recovered' in execution_log, got: {log!r}"
+    )
+
+
+def test_load_executing_does_not_leave_executing_status(tmp_path):  # STO-004
+    """No prompt should have EXECUTING status after load_queue_state()."""
+    storage = QueueStorage(str(tmp_path))
+    _make_executing_file(storage.queue_dir, "abc12345", "crashed", "crashed content")
+    (storage.queue_dir / "def67890-normal.md").write_text(
+        MINIMAL_FRONTMATTER + "normal content"
+    )
+
+    state = storage.load_queue_state()
+
+    assert all(p.status != PromptStatus.EXECUTING for p in state.prompts), (
+        f"Found EXECUTING prompt(s) after load: "
+        f"{[p.id for p in state.prompts if p.status == PromptStatus.EXECUTING]}"
+    )
+
+
+# ===========================================================================
+# Content Corruption / Sentinel
+# ===========================================================================
+
+
+def test_write_prompt_file_includes_execution_log_section(tmp_path):  # STO-005
+    """write_prompt_file() must write '## Execution Log' before the log body
+    so the parser can cleanly split the two sections.
+    """
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(id="abc12345", content="my task")
+    prompt.add_log("Step 1 done")
+    file_path = storage.queue_dir / "abc12345-my-task.md"
+    storage.parser.write_prompt_file(prompt, file_path)
+    raw = file_path.read_text()
+    assert "## Execution Log" in raw
+
+
+def test_parse_strips_sentinel_log_from_content(tmp_path):  # STO-006
+    """parse_prompt_file() must not include the sentinel or log in content."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-my-task.md"
+    file_path.write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 3\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\n"
+        "my task content\n\n"
+        "<!-- claude-queue:execution-log -->\n"
+        "```\n[2025-01-01 12:00:00] Step 1 done\n```\n"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert "<!-- claude-queue:execution-log -->" not in prompt.content
+    assert "Step 1 done" not in prompt.content
+    assert prompt.content.strip() == "my task content"
+
+
+def test_parse_strips_legacy_execution_log_from_content(tmp_path):  # STO-007
+    """Legacy '## Execution Log' separator must also be stripped
+    (backwards compatibility with files written before the sentinel existed).
+    """
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-my-task.md"
+    file_path.write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 3\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\n"
+        "original content\n\n"
+        "## Execution Log\n\n"
+        "```\n[2025-01-01 12:00:00] Some log entry\n```\n"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert "## Execution Log" not in prompt.content
+    assert "Some log entry" not in prompt.content
+    assert prompt.content.strip() == "original content"
+
+
+def test_content_survives_write_parse_roundtrip_with_log(tmp_path):  # STO-008
+    """Content is unchanged after write → add log → write again → parse."""
+    storage = QueueStorage(str(tmp_path))
+    original_content = "Fix the authentication module and add unit tests."
+    prompt = QueuedPrompt(id="abc12345", content=original_content)
+    file_path = storage.queue_dir / "abc12345-fix-the-authentication.md"
+    storage.parser.write_prompt_file(prompt, file_path)
+    prompt.add_log("First attempt failed")
+    storage.parser.write_prompt_file(prompt, file_path)
+    parsed = storage.parser.parse_prompt_file(file_path)
+    assert parsed is not None
+    assert parsed.content == original_content
+
+
+def test_content_without_log_unchanged(tmp_path):  # STO-009
+    """Write/parse with no log entries: content must be identical to original."""
+    storage = QueueStorage(str(tmp_path))
+    content = "Simple task with no log entries."
+    prompt = QueuedPrompt(id="abc12345", content=content)
+    file_path = storage.queue_dir / "abc12345-simple-task.md"
+    storage.parser.write_prompt_file(prompt, file_path)
+    parsed = storage.parser.parse_prompt_file(file_path)
+    assert parsed is not None
+    assert parsed.content == content
+
+
+def test_log_section_present_in_raw_file(tmp_path):  # STO-010
+    """Even if the log is stripped from content on parse, it must be on disk."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(id="abc12345", content="task")
+    prompt.add_log("Execution started")
+    file_path = storage.queue_dir / "abc12345-task.md"
+    storage.parser.write_prompt_file(prompt, file_path)
+    raw = file_path.read_text()
+    assert "Execution started" in raw
+
+
+# ===========================================================================
+# Rate-Limit Persistence
+# ===========================================================================
+
+
+def test_retry_count_persisted_and_reloaded(tmp_path):  # STO-011
+    """retry_count is written to frontmatter and reloaded correctly."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(id="abc12345", content="task")
+    prompt.retry_count = 2
+    state = QueueState()
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+    reloaded = storage.load_queue_state()
+    assert reloaded.prompts[0].retry_count == 2
+
+
+def test_rate_limited_at_persisted_and_reloaded(tmp_path):  # STO-012
+    """rate_limited_at datetime survives a save/load cycle."""
+    storage = QueueStorage(str(tmp_path))
+    ts = datetime(2025, 1, 1, 12, 0, 0)
+    prompt = QueuedPrompt(id="abc12345", content="task")
+    prompt.status = PromptStatus.RATE_LIMITED
+    prompt.rate_limited_at = ts
+    state = QueueState()
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+    reloaded = storage.load_queue_state()
+    assert reloaded.prompts[0].rate_limited_at is not None
+    delta = abs(
+        (reloaded.prompts[0].rate_limited_at - ts).total_seconds()
+    )
+    assert delta < 1, (
+        f"rate_limited_at drifted by {delta:.3f}s; expected < 1s"
+    )
+
+
+def test_reset_time_persisted_and_reloaded(tmp_path):  # STO-013
+    """reset_time datetime survives a save/load cycle."""
+    storage = QueueStorage(str(tmp_path))
+    ts = datetime(2025, 6, 1, 15, 0, 0)
+    prompt = QueuedPrompt(id="abc12345", content="task")
+    prompt.status = PromptStatus.RATE_LIMITED
+    prompt.reset_time = ts
+    state = QueueState()
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+    reloaded = storage.load_queue_state()
+    assert reloaded.prompts[0].reset_time is not None
+    delta = abs((reloaded.prompts[0].reset_time - ts).total_seconds())
+    assert delta < 1, f"reset_time drifted by {delta:.3f}s; expected < 1s"
+
+
+def test_last_executed_persisted_and_reloaded(tmp_path):  # STO-014
+    """last_executed datetime survives a save/load cycle."""
+    storage = QueueStorage(str(tmp_path))
+    ts = datetime(2025, 3, 15, 9, 30, 0)
+    prompt = QueuedPrompt(id="abc12345", content="task")
+    prompt.last_executed = ts
+    state = QueueState()
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+    reloaded = storage.load_queue_state()
+    assert reloaded.prompts[0].last_executed is not None
+    delta = abs((reloaded.prompts[0].last_executed - ts).total_seconds())
+    assert delta < 1, f"last_executed drifted by {delta:.3f}s; expected < 1s"
+
+
+def test_parse_optional_datetime_handles_timezone_aware(tmp_path):  # STO-015
+    """_parse_optional_datetime() strips tzinfo to produce a naive datetime."""
+    result = QueueStorage._parse_optional_datetime("2025-01-01T12:00:00+00:00")
+    assert result is not None
+    assert result.tzinfo is None, "Must return naive datetime (no tzinfo)"
+    assert result.year == 2025
+    assert result.hour == 12
+
+
+def test_parse_optional_datetime_handles_none(tmp_path):  # STO-016
+    """_parse_optional_datetime(None) returns None without raising."""
+    result = QueueStorage._parse_optional_datetime(None)
+    assert result is None
+
+
+def test_parse_optional_datetime_handles_invalid_string(tmp_path):  # STO-017
+    """_parse_optional_datetime('not-a-date') returns None without raising."""
+    result = QueueStorage._parse_optional_datetime("not-a-date")
+    assert result is None
+
+
+# ===========================================================================
+# MarkdownPromptParser — frontmatter field reading
+# ===========================================================================
+
+
+def test_parse_reads_priority(tmp_path):  # STO-018
+    """priority: 2 in frontmatter → prompt.priority == 2."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\npriority: 2\nworking_directory: .\nmax_retries: 3\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\nmy task"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert prompt.priority == 2
+
+
+def test_parse_reads_working_directory(tmp_path):  # STO-019
+    """working_directory: /tmp/myproject in frontmatter is faithfully loaded."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\npriority: 0\nworking_directory: /tmp/myproject\nmax_retries: 3\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\ncontent"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert prompt.working_directory == "/tmp/myproject"
+
+
+def test_parse_reads_context_files_as_list(tmp_path):  # STO-020
+    """context_files: [a.py, b.py] in frontmatter → list of two strings."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 3\n"
+        "context_files:\n- a.py\n- b.py\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\ncontent"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert prompt.context_files == ["a.py", "b.py"]
+
+
+def test_parse_reads_max_retries(tmp_path):  # STO-021
+    """max_retries: 5 in frontmatter → prompt.max_retries == 5."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 5\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\ncontent"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert prompt.max_retries == 5
+
+
+def test_parse_reads_estimated_tokens(tmp_path):  # STO-022
+    """estimated_tokens: 1500 in frontmatter → prompt.estimated_tokens == 1500."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 3\n"
+        "estimated_tokens: 1500\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\ncontent"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert prompt.estimated_tokens == 1500
+
+
+def test_parse_estimated_tokens_null(tmp_path):  # STO-023
+    """estimated_tokens: null in frontmatter → prompt.estimated_tokens is None."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 3\n"
+        "estimated_tokens: null\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\ncontent"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert prompt.estimated_tokens is None
+
+
+def test_parse_defaults_when_keys_missing(tmp_path):  # STO-024
+    """Minimal frontmatter → defaults: priority=0, max_retries=3, context_files=[],
+    estimated_tokens=None.
+    """
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\nworking_directory: .\n---\ncontent here"
+    )
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert prompt.priority == 0
+    assert prompt.max_retries == 3
+    assert prompt.context_files == []
+    assert prompt.estimated_tokens is None
+
+
+def test_parse_file_without_frontmatter(tmp_path):  # STO-025
+    """A file with no '---' block must not crash; content is the entire file."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-plain.md"
+    file_path.write_text("Just plain content, no frontmatter at all.")
+    prompt = storage.parser.parse_prompt_file(file_path)
+    assert prompt is not None
+    assert "plain content" in prompt.content
+    assert prompt.priority == 0
+
+
+def test_write_then_parse_roundtrip_preserves_priority(tmp_path):  # STO-026
+    """Write with priority=7 → parse back → priority is still 7."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(id="abc12345", content="task", priority=7)
+    file_path = storage.queue_dir / "abc12345-task.md"
+    storage.parser.write_prompt_file(prompt, file_path)
+    parsed = storage.parser.parse_prompt_file(file_path)
+    assert parsed is not None
+    assert parsed.priority == 7
+
+
+# ===========================================================================
+# Filename Generation
+# ===========================================================================
+
+
+def test_get_base_filename_sanitizes_special_chars():  # STO-027
+    """Special characters in content are removed from the generated filename."""
+    prompt = QueuedPrompt(
+        id="abc12345", content="Fix <auth> module: add/remove tokens?"
+    )
+    filename = MarkdownPromptParser.get_base_filename(prompt)
+    assert "/" not in filename
+    assert "<" not in filename
+    assert ">" not in filename
+    assert "?" not in filename
+    assert filename.startswith("abc12345-")
+
+
+def test_get_base_filename_format():  # STO-028
+    """Generated filename starts with '{id}-' and ends with '.md'."""
+    prompt = QueuedPrompt(id="abc12345", content="some task description")
+    filename = MarkdownPromptParser.get_base_filename(prompt)
+    assert filename.startswith("abc12345-")
+    assert filename.endswith(".md")
+
+
+def test_get_base_filename_empty_content_produces_no_title():  # STO-029
+    """QueuedPrompt with empty content → filename ends with '-no-title.md'."""
+    prompt = QueuedPrompt(id="abc12345", content="")
+    filename = MarkdownPromptParser.get_base_filename(prompt)
+    assert filename.endswith("-no-title.md"), (
+        f"Expected filename to end with '-no-title.md', got: {filename!r}"
+    )
+    assert "--" not in filename.replace("no-title", ""), (
+        "Filename must not contain double-dash before .md"
+    )
+
+
+def test_get_base_filename_whitespace_only_produces_no_title():  # STO-030
+    """Content that sanitizes to empty string (whitespace only) → 'no-title'."""
+    prompt = QueuedPrompt(id="abc12345", content="   ")
+    filename = MarkdownPromptParser.get_base_filename(prompt)
+    assert "no-title" in filename
+
+
+def test_get_base_filename_normal_content_unchanged():  # STO-031
+    """Non-empty content still produces a normal filename."""
+    prompt = QueuedPrompt(id="abc12345", content="Fix the auth module")
+    filename = MarkdownPromptParser.get_base_filename(prompt)
+    assert filename.startswith("abc12345-")
+    assert "no-title" not in filename
+    assert filename.endswith(".md")
+
+
+def test_sanitize_filename_truncates_at_50_chars():  # STO-032
+    """Pure alpha text of 100 chars is truncated to exactly 50 chars."""
+    long_text = "a" * 100
+    result = QueueStorage._sanitize_filename_static(long_text)
+    assert len(result) <= 50
+    assert result == "a" * 50
+
+
+def test_sanitize_filename_collapses_consecutive_dashes():  # STO-033
+    """Multiple consecutive dashes and whitespace are collapsed to a single '-'."""
+    result = QueueStorage._sanitize_filename_static("fix---this   issue")
+    assert "--" not in result, "Consecutive dashes must be collapsed"
+    assert " " not in result, "Spaces must be replaced"
+    assert result == "fix-this-issue"
+
+
+# ===========================================================================
+# QueueStorage — file placement by status
+# ===========================================================================
+
+
+def test_add_prompt_creates_file_in_queue_dir(tmp_path):  # STO-034
+    """save_queue_state() with one QUEUED prompt → exactly one .md in queue_dir."""
+    storage = QueueStorage(str(tmp_path))
+    state = QueueState()
+    prompt = QueuedPrompt(content="task one")
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+    files = list(storage.queue_dir.glob("*.md"))
+    assert len(files) == 1
+
+
+def test_load_queue_state_finds_added_prompt(tmp_path):  # STO-035
+    """After save_queue_state(), load_queue_state() returns the same prompt."""
+    storage = QueueStorage(str(tmp_path))
+    state = QueueState()
+    prompt = QueuedPrompt(id="abc12345", content="remembered task")
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+    reloaded = storage.load_queue_state()
+    ids = [p.id for p in reloaded.prompts]
+    assert "abc12345" in ids
+
+
+def test_executing_file_has_executing_extension(tmp_path):  # STO-036
+    """EXECUTING prompt → file gets .executing.md double extension."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(content="task", status=PromptStatus.EXECUTING)
+    storage._save_single_prompt(prompt)
+    executing_files = list(storage.queue_dir.glob("*.executing.md"))
+    assert len(executing_files) == 1
+
+
+def test_rate_limited_file_has_rate_limited_extension(tmp_path):  # STO-037
+    """RATE_LIMITED prompt → file gets .rate-limited.md double extension."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(content="task", status=PromptStatus.RATE_LIMITED)
+    storage._save_single_prompt(prompt)
+    rl_files = list(storage.queue_dir.glob("*.rate-limited.md"))
+    assert len(rl_files) == 1
+
+
+def test_completed_prompt_moves_to_completed_dir(tmp_path):  # STO-038
+    """COMPLETED prompt → file in completed_dir, nothing left in queue_dir."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(content="task", status=PromptStatus.COMPLETED)
+    storage._save_single_prompt(prompt)
+    files = list(storage.completed_dir.glob("*.md"))
+    assert len(files) == 1
+    queue_files = list(storage.queue_dir.glob(f"{prompt.id}*.md"))
+    assert len(queue_files) == 0
+
+
+def test_failed_prompt_moves_to_failed_dir(tmp_path):  # STO-039
+    """FAILED prompt → file in failed_dir, nothing left in queue_dir."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(content="task", status=PromptStatus.FAILED)
+    storage._save_single_prompt(prompt)
+    files = list(storage.failed_dir.glob("*.md"))
+    assert len(files) == 1
+    queue_files = list(storage.queue_dir.glob(f"{prompt.id}*.md"))
+    assert len(queue_files) == 0
+
+
+def test_cancelled_prompt_naming(tmp_path):  # STO-040
+    """CANCELLED prompt → file in failed_dir with 'cancelled' in name."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(id="abc12345", content="task", status=PromptStatus.CANCELLED)
+    storage._save_single_prompt(prompt)
+    files = list(storage.failed_dir.glob("*cancelled*"))
+    assert len(files) == 1
+
+
+# ===========================================================================
+# Template Operations
+# ===========================================================================
+
+
+def test_create_prompt_template_writes_markdown(tmp_path):  # STO-041
+    """create_prompt_template() creates a file that starts with '---'."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.create_prompt_template("my-task")
+    assert file_path.exists()
+    content = file_path.read_text()
+    assert content.startswith("---")
+
+
+def test_template_contains_required_frontmatter_keys(tmp_path):  # STO-042
+    """Template file includes priority, working_directory, context_files, max_retries."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.create_prompt_template("my-task")
+    content = file_path.read_text()
+    assert "priority" in content
+    assert "working_directory" in content
+    assert "context_files" in content
+    assert "max_retries" in content
+
+
+def test_add_prompt_from_markdown_file(tmp_path):  # STO-043
+    """add_prompt_from_markdown() parses an existing file and returns a QueuedPrompt."""
+    storage = QueueStorage(str(tmp_path))
+    external_file = tmp_path / "my-prompt.md"
+    external_file.write_text(
+        "---\npriority: 1\nworking_directory: /tmp\nmax_retries: 3\n"
+        "status: queued\nretry_count: 0\ncreated_at: 2025-01-01T00:00:00\n---\n\n"
+        "Do something useful."
+    )
+    prompt = storage.add_prompt_from_markdown(external_file)
+    assert prompt is not None
+    assert "Do something useful." in prompt.content
+    assert prompt.status == PromptStatus.QUEUED
+
+
+# ===========================================================================
+# Storage Utility Methods
+# ===========================================================================
+
+
+def test_remove_prompt_files_clears_all_status_variants(tmp_path):  # STO-044
+    """_remove_prompt_files() deletes the plain, .executing, and .rate-limited variants."""
+    storage = QueueStorage(str(tmp_path))
+    prompt_id = "abc12345"
+    (storage.queue_dir / f"{prompt_id}-task.md").write_text("content")
+    (storage.queue_dir / f"{prompt_id}-task.executing.md").write_text("content")
+    (storage.queue_dir / f"{prompt_id}-task.rate-limited.md").write_text("content")
+
+    storage._remove_prompt_files(prompt_id, storage.queue_dir)
+
+    remaining = list(storage.queue_dir.glob(f"{prompt_id}*.md"))
+    assert len(remaining) == 0, f"Files still present: {remaining}"
+
+
+def test_state_stats_persist_across_sessions(tmp_path):  # STO-045
+    """total_processed, failed_count, rate_limited_count survive a save/load cycle."""
+    storage = QueueStorage(str(tmp_path))
+    state = QueueState()
+    state.total_processed = 5
+    state.failed_count = 2
+    state.rate_limited_count = 1
+    storage.save_queue_state(state)
+
+    reloaded = storage.load_queue_state()
+    assert reloaded.total_processed == 5
+    assert reloaded.failed_count == 2
+    assert reloaded.rate_limited_count == 1
+
+
+def test_load_state_without_json_file_returns_defaults(tmp_path):  # STO-046
+    """When no queue-state.json exists, load_queue_state() returns zero counters."""
+    storage = QueueStorage(str(tmp_path))
+    assert not storage.state_file.exists()
+    state = storage.load_queue_state()
+    assert state.total_processed == 0
+    assert state.failed_count == 0
+
+
+def test_load_state_with_corrupt_json_returns_defaults(tmp_path):  # STO-047
+    """Corrupt JSON file does not crash; load_queue_state() returns defaults."""
+    storage = QueueStorage(str(tmp_path))
+    storage.state_file.write_text("{ this is not valid json }")
+    state = storage.load_queue_state()
+    assert state.total_processed == 0
+
+
+# ===========================================================================
+# YAML Error Handling
+# ===========================================================================
+
+
+def test_yaml_parse_error_emits_warning_to_stderr(tmp_path, capsys):  # STO-048
+    """Broken YAML frontmatter → warning on stderr; function does not raise."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\n"
+        "priority: [unclosed bracket\n"
+        "---\n\n"
+        "task content"
+    )
+    result = storage.parser.parse_prompt_file(file_path)
+
+    assert result is not None, "parse_prompt_file must not return None for YAML errors"
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err or "warning" in captured.err.lower(), (
+        f"Expected a warning on stderr, got: {captured.err!r}"
+    )
+
+
+def test_yaml_parse_error_uses_default_values(tmp_path):  # STO-049
+    """Broken YAML frontmatter → returned prompt has default field values."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.queue_dir / "abc12345-task.md"
+    file_path.write_text(
+        "---\n"
+        "priority: [unclosed bracket\n"
+        "---\n\n"
+        "task content"
+    )
+    result = storage.parser.parse_prompt_file(file_path)
+
+    assert result is not None
+    assert result.priority == 0
+    assert result.max_retries == 3
+    assert result.content == "task content"
+
+
+# ===========================================================================
+# File Permissions
+# ===========================================================================
+
+
+def test_storage_directories_have_mode_700(tmp_path):  # STO-050
+    """All queue directories are created with mode 0o700."""
+    storage = QueueStorage(str(tmp_path))
+    for d in [storage.base_dir, storage.queue_dir, storage.completed_dir,
+              storage.failed_dir, storage.bank_dir]:
+        mode = stat.S_IMODE(d.stat().st_mode)
+        assert mode == 0o700, (
+            f"Expected mode 0o700 on {d}, got 0o{mode:o}"
+        )
+
+
+def test_write_prompt_file_has_mode_600(tmp_path):  # STO-051
+    """write_prompt_file() creates a file with mode 0o600."""
+    storage = QueueStorage(str(tmp_path))
+    prompt = QueuedPrompt(id="abc12345", content="task")
+    file_path = storage.queue_dir / "abc12345-task.md"
+    storage.parser.write_prompt_file(prompt, file_path)
+    mode = stat.S_IMODE(file_path.stat().st_mode)
+    assert mode == 0o600, f"Expected mode 0o600, got 0o{mode:o}"
+
+
+def test_create_prompt_template_has_mode_600(tmp_path):  # STO-052
+    """create_prompt_template() creates a file with mode 0o600."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.create_prompt_template("my-task")
+    mode = stat.S_IMODE(file_path.stat().st_mode)
+    assert mode == 0o600, f"Expected mode 0o600, got 0o{mode:o}"
+
+
+def test_save_prompt_to_bank_has_mode_600(tmp_path):  # STO-053
+    """save_prompt_to_bank() creates a file with mode 0o600."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.save_prompt_to_bank("my-template")
+    mode = stat.S_IMODE(file_path.stat().st_mode)
+    assert mode == 0o600, f"Expected mode 0o600, got 0o{mode:o}"
+
+
+# ===========================================================================
+# Bank Operations
+# ===========================================================================
+
+
+def test_bank_save_creates_file_in_bank_dir(tmp_path):  # STO-054
+    """save_prompt_to_bank() creates a file inside bank_dir."""
+    storage = QueueStorage(str(tmp_path))
+    file_path = storage.save_prompt_to_bank("daily-review")
+    assert file_path.exists()
+    assert file_path.parent == storage.bank_dir
+
+
+def test_bank_list_returns_saved_template_names(tmp_path):  # STO-055
+    """list_bank_templates() returns dicts containing the saved template names."""
+    storage = QueueStorage(str(tmp_path))
+    storage.save_prompt_to_bank("alpha")
+    storage.save_prompt_to_bank("beta")
+    templates = storage.list_bank_templates()
+    names = [t["name"] for t in templates]
+    assert "alpha" in names
+    assert "beta" in names
+
+
+def test_bank_list_empty_when_no_templates(tmp_path):  # STO-056
+    """list_bank_templates() returns [] when the bank directory is empty."""
+    storage = QueueStorage(str(tmp_path))
+    assert storage.list_bank_templates() == []
+
+
+def test_bank_use_copies_prompt_to_queue(tmp_path):  # STO-057
+    """use_bank_template() returns a QueuedPrompt; saving it creates a queue file."""
+    storage = QueueStorage(str(tmp_path))
+    storage.save_prompt_to_bank("daily")
+    (storage.bank_dir / "daily.md").write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 3\n---\n\nDaily review prompt"
+    )
+    prompt = storage.use_bank_template("daily")
+    assert prompt is not None
+    state = QueueState()
+    state.add_prompt(prompt)
+    storage.save_queue_state(state)
+    files = list(storage.queue_dir.glob("*.md"))
+    assert len(files) == 1
+
+
+def test_bank_use_preserves_priority_from_template(tmp_path):  # STO-058
+    """Priority from the bank template is copied to the new QueuedPrompt."""
+    storage = QueueStorage(str(tmp_path))
+    storage.save_prompt_to_bank("priority-test", priority=2)
+    (storage.bank_dir / "priority-test.md").write_text(
+        "---\npriority: 2\nworking_directory: .\nmax_retries: 3\n---\n\nContent"
+    )
+    prompt = storage.use_bank_template("priority-test")
+    assert prompt is not None
+    assert prompt.priority == 2
+
+
+def test_bank_use_preserves_max_retries_from_template(tmp_path):  # STO-059
+    """max_retries from the bank template is copied to the new QueuedPrompt."""
+    storage = QueueStorage(str(tmp_path))
+    (storage.bank_dir / "retry-test.md").write_text(
+        "---\npriority: 0\nworking_directory: .\nmax_retries: 5\n---\n\nContent"
+    )
+    prompt = storage.use_bank_template("retry-test")
+    assert prompt is not None
+    assert prompt.max_retries == 5
+
+
+def test_bank_delete_removes_template(tmp_path):  # STO-060
+    """delete_bank_template() removes the bank file."""
+    storage = QueueStorage(str(tmp_path))
+    storage.save_prompt_to_bank("temp")
+    storage.delete_bank_template("temp")
+    assert not (storage.bank_dir / "temp.md").exists()
+
+
+def test_bank_delete_nonexistent_returns_false(tmp_path):  # STO-061
+    """delete_bank_template() returns False when the template does not exist."""
+    storage = QueueStorage(str(tmp_path))
+    result = storage.delete_bank_template("does-not-exist")
+    assert result is False
+
+
+def test_bank_template_priority_configurable(tmp_path):  # STO-062
+    """save_prompt_to_bank('task', priority=5) writes 'priority: 5' in the YAML."""
+    storage = QueueStorage(str(tmp_path))
+    storage.save_prompt_to_bank("my-task", priority=5)
+    content = (storage.bank_dir / "my-task.md").read_text()
+    assert "priority: 5" in content
+
+
+def test_bank_use_nonexistent_template_returns_none(tmp_path):  # STO-063
+    """use_bank_template() returns None when the template does not exist."""
+    storage = QueueStorage(str(tmp_path))
+    result = storage.use_bank_template("nonexistent")
+    assert result is None
+
+
+def test_bank_list_returns_full_metadata(tmp_path):  # STO-064
+    """list_bank_templates() dicts include name, title, priority, working_directory,
+    estimated_tokens (None by default), and a non-None modified timestamp.
+    """
+    storage = QueueStorage(str(tmp_path))
+    storage.save_prompt_to_bank("my-template", priority=3)
+    templates = storage.list_bank_templates()
+    assert len(templates) == 1
+    t = templates[0]
+    assert t["name"] == "my-template"
+    assert t["priority"] == 3
+    assert t["working_directory"] == "."
+    assert t["estimated_tokens"] is None
+    assert "modified" in t and t["modified"] is not None
+    assert "title" in t and len(t["title"]) > 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -433,13 +433,15 @@ def test_write_then_parse_roundtrip_preserves_priority(tmp_path):  # STO-026
 def test_get_base_filename_sanitizes_special_chars():  # STO-027
     """Special characters in content are removed from the generated filename."""
     prompt = QueuedPrompt(
-        id="abc12345", content="Fix <auth> module: add/remove tokens?"
+        id="abc12345", content="Fix <auth> module: add/remove tokens? it's `done`"
     )
     filename = MarkdownPromptParser.get_base_filename(prompt)
     assert "/" not in filename
     assert "<" not in filename
     assert ">" not in filename
     assert "?" not in filename
+    assert "'" not in filename
+    assert "`" not in filename
     assert filename.startswith("abc12345-")
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -863,3 +863,43 @@ def test_bank_list_returns_full_metadata(tmp_path):  # STO-064
     assert t["estimated_tokens"] is None
     assert "modified" in t and t["modified"] is not None
     assert "title" in t and len(t["title"]) > 0
+
+
+# ===========================================================================
+# _parse_optional_datetime() Fast-Paths (STO-040..042)
+# ===========================================================================
+
+
+def test_parse_optional_datetime_native_datetime_object():  # STO-040
+    """PyYAML returns a native datetime when the YAML value matches the
+    timestamp pattern (e.g. an unquoted isoformat). _parse_optional_datetime()
+    must handle this instead of passing it to fromisoformat() (which requires
+    a str and raises TypeError, silently swallowed by the except clause).
+    """
+    from datetime import datetime as dt
+    native_dt = dt(2025, 6, 1, 15, 0, 0)
+    result = QueueStorage._parse_optional_datetime(native_dt)
+    assert result == native_dt
+    assert result.tzinfo is None
+
+
+def test_parse_optional_datetime_aware_datetime_stripped():  # STO-041
+    """A timezone-aware datetime from PyYAML must have tzinfo stripped
+    (the codebase uses naive datetimes throughout).
+    """
+    from datetime import datetime as dt, timezone
+    aware_dt = dt(2025, 6, 1, 15, 0, 0, tzinfo=timezone.utc)
+    result = QueueStorage._parse_optional_datetime(aware_dt)
+    assert result == dt(2025, 6, 1, 15, 0, 0)
+    assert result.tzinfo is None
+
+
+def test_parse_optional_datetime_date_object():  # STO-042
+    """PyYAML returns a datetime.date (not datetime) for date-only YAML values
+    like `retry_not_before: 2025-06-01` (no time component).
+    _parse_optional_datetime() must convert it to a datetime at midnight.
+    """
+    from datetime import date, datetime as dt
+    result = QueueStorage._parse_optional_datetime(date(2025, 6, 1))
+    assert result == dt(2025, 6, 1, 0, 0, 0)
+    assert result.tzinfo is None


### PR DESCRIPTION
## Summary

- **Problem**: Pressing Ctrl+C set `self.running = False` but the main thread was blocked inside `subprocess.run()` — the child `claude` process ran to completion (potentially consuming all remaining tokens) before the queue shut down.
- **Fix**: Replace `subprocess.run()` with `Popen` + `communicate()` to retain a handle to the child process. The signal handler now calls `kill_current()` which sends SIGTERM to the entire process group, with a daemon thread that escalates to SIGKILL after 3 seconds.
- **Key details**: Uses `start_new_session=True` so the child is a process group leader (all children terminated together), `os.write(2, ...)` in signal handler to avoid stream lock re-entry, atexit handler as defense-in-depth against orphaned subprocesses, and context manager protocol for clean test teardown.

## Test plan

- [x] All 451 existing tests pass
- [x] New tests cover `kill_current()`, `_kill_proc_group()`, SIGKILL escalation, `_was_interrupted` flag, atexit cleanup, and context manager protocol
- [x] Tests for `TimeoutExpired` and `BaseException` cleanup paths in `execute_prompt()`
- [x] Tests for signal handler calling `kill_current()` before `stop()`
- [ ] Manual: run queue with a long prompt, press Ctrl+C, verify subprocess is killed immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)