### PR TITLE
fix: prevent shared-prefix batch files from deleting each other's queue entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 src/claude_code_queue.egg-info/
 dev.md
+__pycache__/
+*.pyc

--- a/src/claude_code_queue/storage.py
+++ b/src/claude_code_queue/storage.py
@@ -242,6 +242,22 @@ class QueueStorage:
                 self._remove_prompt_files(prompt.id, self.queue_dir)
             else:  # QUEUED
                 target_dir = self.queue_dir
+                # Fix 1b — Remove any stale .executing.md or .rate-limited.md file
+                # left over from a previous run that crashed before transitioning.
+                # Without this, the orphaned file is picked up on reload as EXECUTING,
+                # causing the retried QUEUED file to be ignored.
+                #
+                # IMPORTANT: Use exact filenames (not globs) so we only remove THIS
+                # prompt's stale suffixed files. A glob like "{id}-*.executing.md"
+                # would also match sibling prompts that share the same id prefix
+                # (e.g. all "reorder-kernel*.md" files share id="reorder"), deleting
+                # the currently-running job's .executing.md crash-recovery file.
+                for suffix in (".executing.md", ".rate-limited.md"):
+                    stale = self.queue_dir / base_filename.replace(".md", suffix)
+                    try:
+                        stale.unlink(missing_ok=True)
+                    except Exception as e:
+                        print(f"Error removing file {stale}: {e}")
             file_path = target_dir / base_filename
             return self.parser.write_prompt_file(prompt, file_path)
         except Exception as e:


### PR DESCRIPTION
## Summary

- **Root cause**: `_save_single_prompt()` called `_remove_prompt_files(prompt_id, ...)` for QUEUED prompts, which uses a `{id}*.md` glob. When multiple prompt files share the same filename prefix (e.g. `reorder-kernel1.md`, `reorder-kernel2.md` → `prompt_id = "reorder"` for all), this glob deleted all 139 sibling files in one sweep, then wrote only 1 back. The queue appeared to drain instantly.
- **Fix**: Replace glob-based cleanup with exact filename matching. When re-queuing a prompt, only remove the two possible stale suffixed variants (`.executing.md` and `.rate-limited.md`) derived from the prompt's own `base_filename`. This leaves all sibling files untouched.
- **Why the stale-file cleanup is needed at all**: Without it, a `.executing.md` file orphaned by a crash would be reloaded as `EXECUTING` on restart, causing the re-queued prompt to be ignored (Fix 1b scenario).

## Test plan

- [ ] Create 10+ batch prompt files with a shared filename prefix (e.g. `reorder-kernel1.md` … `reorder-kernel10.md`)
- [ ] Start the queue processor and verify all files remain in the queue directory while one executes
- [ ] Kill the queue processor mid-execution, restart it, and verify the interrupted job resumes (stale `.executing.md` cleanup still works)
- [ ] Verify a prompt that gets rate-limited then re-queued cleans up its own `.rate-limited.md` without touching siblings

🤖 Generated with [Claude Code](https://claude.com/claude-code)