### PR TITLE
fix: clean up rate-limit artifacts on detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ run `pip install --force-reinstall claude-code-queue`.
 (`libxcb-dev` on Debian/Ubuntu, `libxcb-devel` on Fedora/RHEL, `libxcb` on Arch).
 At runtime, clipboard support requires `xclip` or `xsel` to be installed.
 
+### Claude Code Skill (optional)
+
+If you use [Claude Code](https://claude.ai/code), install the bundled `/queue`
+skill so Claude can help you construct and manage queue tasks:
+
+```bash
+claude-queue install-skill
+```
+
+This copies a `SKILL.md` to `~/.claude/skills/queue/`. After restarting Claude
+Code, type `/queue` to invoke it directly, and Claude will also proactively
+suggest queuing when a task is complex or likely to hit rate limits. Use
+`--force` to update an existing installation after upgrading the package.
+
 Or, for local development:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev = ["pytest", "pytest-mock"]
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-claude_code_queue = ["py.typed"]
+claude_code_queue = ["py.typed", "skills/**/*"]
 
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-mock"]
+eval = ["pytest", "pytest-mock", "anthropic>=0.40.0"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/claude_code_queue/batch.py
+++ b/src/claude_code_queue/batch.py
@@ -1,0 +1,183 @@
+"""
+Batch template generation for Claude Code Queue.
+
+Generates multiple queue jobs from a template with {{variable}} placeholders
+and a CSV/TSV data file where each row produces one job.
+"""
+
+import csv
+import re
+import tempfile
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from .models import QueuedPrompt, PromptStatus
+from .storage import MarkdownPromptParser, QueueStorage
+
+VARIABLE_PATTERN = re.compile(r"\{\{(\w+)\}\}")
+
+
+def extract_variables(text: str) -> Set[str]:
+    """Find all {{variable}} names in template text."""
+    return set(VARIABLE_PATTERN.findall(text))
+
+
+def render_template(text: str, values: Dict[str, str]) -> str:
+    """Replace {{var}} placeholders with values.
+
+    Raises ValueError if any placeholders remain after substitution.
+    """
+    result = text
+    for var, val in values.items():
+        result = result.replace(f"{{{{{var}}}}}", val)
+
+    remaining = extract_variables(result)
+    if remaining:
+        raise ValueError(f"Unreplaced template variables: {remaining}")
+
+    return result
+
+
+def read_data_file(data_path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    """Read a CSV/TSV data file.
+
+    Returns (column_names, rows_as_dicts).
+    Uses csv.Sniffer for automatic delimiter detection.
+    """
+    with open(data_path, "r", newline="", encoding="utf-8") as f:
+        sample = f.read(8192)
+        f.seek(0)
+
+        try:
+            dialect = csv.Sniffer().sniff(sample, delimiters=",\t;|")
+        except csv.Error:
+            dialect = csv.excel  # default to comma-delimited
+
+        reader = csv.DictReader(f, dialect=dialect)
+        columns = reader.fieldnames or []
+        rows = list(reader)
+
+    return columns, rows
+
+
+def validate_batch(
+    template_vars: Set[str],
+    data_columns: List[str],
+) -> Tuple[List[str], List[str]]:
+    """Validate template variables against data columns.
+
+    Returns (errors, warnings).
+    """
+    errors = []
+    warnings = []
+
+    col_set = set(data_columns)
+    missing = template_vars - col_set
+    if missing:
+        errors.append(
+            f"Template variables not found in data columns: {sorted(missing)}"
+        )
+
+    extra = col_set - template_vars
+    if extra:
+        warnings.append(
+            f"Data columns not referenced in template: {sorted(extra)}"
+        )
+
+    return errors, warnings
+
+
+def resolve_template_path(template_ref: str, bank_dir: Path) -> Path:
+    """Resolve a template reference to a file path.
+
+    Resolution order:
+    1. If template_ref is an existing file path, use it directly
+    2. Else look for bank/<template_ref>.md
+    3. Else raise FileNotFoundError
+    """
+    # Check as direct file path
+    direct = Path(template_ref)
+    if direct.is_file():
+        return direct
+
+    # Check in bank directory
+    bank_path = bank_dir / f"{template_ref}.md"
+    if bank_path.is_file():
+        return bank_path
+
+    raise FileNotFoundError(
+        f"Template '{template_ref}' not found as file path or in bank/ directory"
+    )
+
+
+def generate_batch_jobs(
+    template_path: Path,
+    data_path: Path,
+    storage: QueueStorage,
+    base_priority: Optional[int] = None,
+    priority_step: int = 1,
+    dry_run: bool = False,
+) -> List[QueuedPrompt]:
+    """Generate queue jobs from a template and data file.
+
+    For each row in the data file:
+    1. Render the template with the row's values
+    2. Parse the rendered text as a prompt file
+    3. Assign a fresh ID and reset execution state
+    4. Optionally override priority with auto-incrementing values
+    5. Save to queue/ (unless dry_run)
+
+    Returns the list of generated QueuedPrompt objects.
+    """
+    template_text = template_path.read_text(encoding="utf-8")
+    columns, rows = read_data_file(data_path)
+
+    # Validate before generating
+    template_vars = extract_variables(template_text)
+    errors, warnings = validate_batch(template_vars, columns)
+    if errors:
+        raise ValueError("\n".join(errors))
+
+    prompts = []
+    parser = MarkdownPromptParser()
+
+    for i, row in enumerate(rows):
+        rendered = render_template(template_text, row)
+
+        # Write to temp file so we can use the existing parser
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(rendered)
+            tmp_path = Path(tmp.name)
+
+        try:
+            prompt = parser.parse_prompt_file(tmp_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        if not prompt:
+            raise ValueError(f"Failed to parse rendered template for row {i + 1}: {row}")
+
+        # Fresh identity for each generated job
+        prompt.id = str(uuid.uuid4())[:8]
+        prompt.status = PromptStatus.QUEUED
+        prompt.created_at = datetime.now()
+        prompt.retry_count = 0
+        prompt.execution_log = ""
+        prompt.last_executed = None
+        prompt.rate_limited_at = None
+        prompt.reset_time = None
+
+        # Priority override
+        if base_priority is not None:
+            prompt.priority = base_priority + i * priority_step
+
+        if not dry_run:
+            storage._save_single_prompt(prompt)
+
+        prompts.append(prompt)
+
+    return prompts

--- a/src/claude_code_queue/cli.py
+++ b/src/claude_code_queue/cli.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 from datetime import datetime
+from pathlib import Path
 
 from .batch import (
     extract_variables,
@@ -701,8 +702,6 @@ def cmd_batch_variables(args) -> int:
 
 def cmd_install_skill(args) -> int:
     """Install the Claude Code skill file to ~/.claude/skills/queue/SKILL.md."""
-    from pathlib import Path
-
     dest = Path.home() / ".claude" / "skills" / "queue" / "SKILL.md"
     skill_src = Path(__file__).parent / "skills" / "queue" / "SKILL.md"
 

--- a/src/claude_code_queue/cli.py
+++ b/src/claude_code_queue/cli.py
@@ -12,6 +12,13 @@ import subprocess
 import sys
 from datetime import datetime
 
+from .batch import (
+    extract_variables,
+    generate_batch_jobs,
+    read_data_file,
+    resolve_template_path,
+    validate_batch,
+)
 from .queue_manager import QueueManager
 from .storage import QueueStorage
 from .models import QueuedPrompt, PromptStatus
@@ -44,6 +51,15 @@ Examples:
   # Use a template from bank (adds to queue)
   python -m claude_code_queue.cli bank use update-docs
 
+  # Generate batch jobs from template + CSV
+  python -m claude_code_queue.cli batch generate my-template --data entries.csv
+
+  # Preview batch generation (dry run)
+  python -m claude_code_queue.cli batch generate my-template --data entries.csv --dry-run
+
+  # List variables in a batch template
+  python -m claude_code_queue.cli batch variables my-template
+
   # Check queue status
   python -m claude_code_queue.cli status
 
@@ -52,6 +68,9 @@ Examples:
 
   # Test Claude Code connection
   python -m claude_code_queue.cli test
+
+  # Install the Claude Code /queue skill
+  python -m claude_code_queue.cli install-skill
         """,
     )
 
@@ -166,6 +185,61 @@ Examples:
     bank_delete_parser = bank_subparsers.add_parser("delete", help="Delete template from bank")
     bank_delete_parser.add_argument("template_name", help="Template name to delete")
 
+    # Batch subcommands
+    batch_parser = subparsers.add_parser(
+        "batch", help="Generate jobs from a template and data file"
+    )
+    batch_subparsers = batch_parser.add_subparsers(
+        dest="batch_command", help="Batch operations"
+    )
+
+    batch_generate_parser = batch_subparsers.add_parser(
+        "generate", help="Generate queue jobs from template + data"
+    )
+    batch_generate_parser.add_argument(
+        "template", help="Bank template name or path to template file"
+    )
+    batch_generate_parser.add_argument(
+        "--data", "-d", required=True, help="Path to CSV/TSV data file"
+    )
+    batch_generate_parser.add_argument(
+        "--base-priority", type=int, default=None,
+        help="Starting priority (auto-increments per row)",
+    )
+    batch_generate_parser.add_argument(
+        "--priority-step", type=int, default=1,
+        help="Priority increment per row (default: 1)",
+    )
+    batch_generate_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Preview what would be generated without creating jobs",
+    )
+
+    batch_validate_parser = batch_subparsers.add_parser(
+        "validate", help="Validate template variables against data columns"
+    )
+    batch_validate_parser.add_argument(
+        "template", help="Bank template name or path to template file"
+    )
+    batch_validate_parser.add_argument(
+        "--data", "-d", required=True, help="Path to CSV/TSV data file"
+    )
+
+    batch_variables_parser = batch_subparsers.add_parser(
+        "variables", help="List template variables ({{placeholders}})"
+    )
+    batch_variables_parser.add_argument(
+        "template", help="Bank template name or path to template file"
+    )
+
+    # Install skill subcommand
+    install_skill_parser = subparsers.add_parser(
+        "install-skill", help="Install the Claude Code skill to ~/.claude/skills/"
+    )
+    install_skill_parser.add_argument(
+        "--force", action="store_true", help="Overwrite existing skill file"
+    )
+
     # Prompt box subcommand
     prompt_box_parser = subparsers.add_parser(
         "prompt-box", help="Launch the interactive prompt box CLI", add_help=False
@@ -200,6 +274,10 @@ Examples:
             return cmd_list(args)
         elif args.command == "bank":
             return cmd_bank(args)
+        elif args.command == "batch":
+            return cmd_batch(args)
+        elif args.command == "install-skill":
+            return cmd_install_skill(args)
         elif args.command == "prompt-box":
             return cmd_prompt_box(args)
         else:
@@ -494,6 +572,154 @@ def cmd_bank_delete(args) -> int:
     else:
         print(f"✗ Template '{args.template_name}' not found in bank")
     return 0 if success else 1
+
+
+def cmd_batch(args) -> int:
+    """Handle batch subcommands."""
+    if not args.batch_command:
+        print("Error: No batch operation specified")
+        print("Available operations: generate, validate, variables")
+        return 1
+
+    if args.batch_command == "generate":
+        return cmd_batch_generate(args)
+    elif args.batch_command == "validate":
+        return cmd_batch_validate(args)
+    elif args.batch_command == "variables":
+        return cmd_batch_variables(args)
+    else:
+        print(f"Unknown batch operation: {args.batch_command}")
+        return 1
+
+
+def cmd_batch_generate(args) -> int:
+    """Generate queue jobs from a template and data file."""
+    storage = QueueStorage(storage_dir=args.storage_dir)
+    data_path = Path(args.data)
+
+    if not data_path.is_file():
+        print(f"Data file not found: {args.data}")
+        return 1
+
+    try:
+        template_path = resolve_template_path(args.template, storage.bank_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        return 1
+
+    try:
+        prompts = generate_batch_jobs(
+            template_path=template_path,
+            data_path=data_path,
+            storage=storage,
+            base_priority=args.base_priority,
+            priority_step=args.priority_step,
+            dry_run=args.dry_run,
+        )
+    except (ValueError, FileNotFoundError) as e:
+        print(f"Error: {e}")
+        return 1
+
+    if args.dry_run:
+        print(f"Dry run: would generate {len(prompts)} job(s)")
+        print("-" * 60)
+        for i, prompt in enumerate(prompts):
+            print(f"  [{i + 1}] P{prompt.priority} | {prompt.working_directory}")
+            print(f"      {prompt.content[:70]}{'...' if len(prompt.content) > 70 else ''}")
+    else:
+        print(f"Generated {len(prompts)} job(s) from template '{args.template}'")
+        if prompts:
+            priorities = [p.priority for p in prompts]
+            print(f"  Priority range: {min(priorities)}–{max(priorities)}")
+
+    return 0
+
+
+def cmd_batch_validate(args) -> int:
+    """Validate template variables against data columns."""
+    storage = QueueStorage(storage_dir=args.storage_dir)
+    data_path = Path(args.data)
+
+    if not data_path.is_file():
+        print(f"Data file not found: {args.data}")
+        return 1
+
+    try:
+        template_path = resolve_template_path(args.template, storage.bank_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        return 1
+
+    template_text = template_path.read_text(encoding="utf-8")
+    template_vars = extract_variables(template_text)
+    columns, rows = read_data_file(data_path)
+    errors, warnings = validate_batch(template_vars, columns)
+
+    print(f"Template: {template_path}")
+    print(f"Data: {data_path} ({len(rows)} row(s), {len(columns)} column(s))")
+    print(f"Variables: {sorted(template_vars) if template_vars else '(none)'}")
+    print(f"Columns: {columns if columns else '(none)'}")
+
+    if errors:
+        for err in errors:
+            print(f"\nError: {err}")
+    if warnings:
+        for warn in warnings:
+            print(f"\nWarning: {warn}")
+
+    if not errors and not warnings:
+        print(f"\nValid: {len(rows)} job(s) would be generated")
+    elif not errors:
+        print(f"\nValid with warnings: {len(rows)} job(s) would be generated")
+
+    return 1 if errors else 0
+
+
+def cmd_batch_variables(args) -> int:
+    """List template variables."""
+    storage = QueueStorage(storage_dir=args.storage_dir)
+
+    try:
+        template_path = resolve_template_path(args.template, storage.bank_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        return 1
+
+    template_text = template_path.read_text(encoding="utf-8")
+    variables = extract_variables(template_text)
+
+    print(f"Template: {template_path}")
+    if variables:
+        print(f"Variables ({len(variables)}):")
+        for var in sorted(variables):
+            print(f"  {{{{{var}}}}}")
+    else:
+        print("No variables found in template")
+
+    return 0
+
+
+def cmd_install_skill(args) -> int:
+    """Install the Claude Code skill file to ~/.claude/skills/queue/SKILL.md."""
+    from pathlib import Path
+
+    dest = Path.home() / ".claude" / "skills" / "queue" / "SKILL.md"
+    skill_src = Path(__file__).parent / "skills" / "queue" / "SKILL.md"
+
+    if not skill_src.exists():
+        print("Error: bundled SKILL.md not found in package installation.")
+        return 1
+
+    if dest.exists() and not args.force:
+        print(f"Skill already installed at {dest}")
+        print("Use --force to overwrite.")
+        return 1
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(skill_src.read_text(encoding="utf-8"), encoding="utf-8")
+    print(f"Skill installed to {dest}")
+    print("Restart Claude Code for the /queue skill to become available.")
+    return 0
 
 
 def cmd_prompt_box(args) -> int:

--- a/src/claude_code_queue/models.py
+++ b/src/claude_code_queue/models.py
@@ -148,6 +148,16 @@ class QueueState:
     def get_next_prompt(self) -> Optional[QueuedPrompt]:
         """Get the next prompt to execute (highest priority, can execute now)."""
         now = datetime.now()
+
+        # If any prompt is actively rate-limited (reset window not yet reached),
+        # don't start new work — we're already known to be rate-limited and firing
+        # more requests would just pile up additional rate-limit hits.
+        if any(
+            p.status == PromptStatus.RATE_LIMITED and not p.should_execute_now(now)
+            for p in self.prompts
+        ):
+            return None
+
         executable_prompts = [
             p
             for p in self.prompts

--- a/src/claude_code_queue/models.py
+++ b/src/claude_code_queue/models.py
@@ -39,6 +39,7 @@ class QueuedPrompt:
     rate_limited_at: Optional[datetime] = None
     reset_time: Optional[datetime] = None
     retry_not_before: Optional[datetime] = None  # Fix 3: earliest time for next generic retry
+    _resolved_working_directory: Optional[str] = field(default=None, repr=False)  # transient; not persisted to YAML
 
     def add_log(self, message: str) -> None:
         """Add a log entry with timestamp."""

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -7,7 +7,8 @@ import sys
 import time
 import signal
 from datetime import datetime, timedelta
-from typing import Optional, Callable, Dict, Any
+from pathlib import Path
+from typing import List, Optional, Callable, Dict, Any
 
 from .models import QueuedPrompt, QueueState, PromptStatus, ExecutionResult
 from .storage import QueueStorage
@@ -238,6 +239,13 @@ class QueueManager:
         prompt.status = PromptStatus.EXECUTING
         prompt.clear_retry_backoff()    # consumed; clear so it doesn't persist into .executing.md
         prompt.last_executed = datetime.now()
+        # Resolve working_directory once and stash it so cleanup uses the same
+        # path that claude_interface.execute_prompt() will use (avoids the bug
+        # where "." resolves to the queue-runner's CWD at cleanup time rather
+        # than at execution time).
+        prompt._resolved_working_directory = str(
+            Path(prompt.working_directory).resolve()
+        )
         retries_str = "∞" if prompt.max_retries == -1 else str(prompt.max_retries)
         prompt.add_log(
             f"Started execution (attempt {prompt.retry_count + 1}/{retries_str})"
@@ -314,6 +322,8 @@ class QueueManager:
                 self.state.rate_limited_count += 1
             print(f"⚠ Prompt {prompt.id} rate limited, will retry later")
 
+            self._cleanup_rate_limit_artifacts(prompt)
+
         else:
             prompt.retry_count += 1
 
@@ -349,6 +359,108 @@ class QueueManager:
                 )
 
         self.state.last_processed = datetime.now()
+
+    def _cleanup_rate_limit_artifacts(self, prompt: QueuedPrompt) -> None:
+        """Remove JSONL, todo, debug, and telemetry files from a rate-limited execution.
+
+        Safety layers:
+        1. Only files with mtime >= prompt.last_executed are considered
+        2. JSONL files must also be < 10 KB (rate-limited: 3-5 KB; successful: 100+ KB)
+        3. Todo files must be <= 2 bytes (the empty "[]" stub)
+        4. Debug and telemetry files are deleted only by UUID correlation with an
+           already-identified rate-limited JSONL file — no size heuristic needed
+
+        Wrapped in a top-level try/except so cleanup failures can never break the
+        execution-result pipeline (which must complete to persist the prompt's
+        RATE_LIMITED status to disk).
+        """
+        if not prompt.last_executed:
+            return
+
+        try:
+            self._do_cleanup_rate_limit_artifacts(prompt)
+        except Exception as e:
+            # Log but never propagate — cleanup is best-effort.
+            # Propagating would prevent save_queue_state() from running,
+            # leaving the prompt as .executing.md on disk and causing a
+            # re-queue loop on restart.
+            prompt.add_log(f"Warning: artifact cleanup failed: {e}")
+            print(f"Warning: artifact cleanup failed: {e}")
+
+    def _do_cleanup_rate_limit_artifacts(self, prompt: QueuedPrompt) -> None:
+        """Inner implementation — may raise; caller catches all exceptions."""
+        cutoff = prompt.last_executed.timestamp()
+        claude_dir = Path.home() / ".claude"
+        deleted = 0
+        rate_limited_uuids: List[str] = []
+
+        # 1. JSONL conversation logs — primary identification of rate-limited sessions
+        #    Use the resolved path stashed by _execute_prompt() so we match the
+        #    exact directory that claude_interface used, even when working_directory
+        #    was relative (e.g. ".").
+        resolved = prompt._resolved_working_directory or str(
+            Path(prompt.working_directory).resolve()
+        )
+        encoded = resolved.replace("/", "-")
+        jsonl_dir = claude_dir / "projects" / encoded
+        if jsonl_dir.is_dir():
+            for f in jsonl_dir.glob("*.jsonl"):
+                try:
+                    st = f.stat()
+                    if st.st_mtime >= cutoff and st.st_size < 10_000:
+                        rate_limited_uuids.append(f.stem)
+                        f.unlink()
+                        deleted += 1
+                        break  # one subprocess = one session UUID
+                except OSError:
+                    pass  # file already gone or inaccessible
+
+        # 2. Todo stub files — by UUID correlation with size guard
+        #    Pattern: <session_uuid>-agent-<session_uuid>.json
+        #    Rate-limited stubs are exactly 2 bytes ("[]")
+        todos_dir = claude_dir / "todos"
+        if todos_dir.is_dir() and rate_limited_uuids:
+            for session_uuid in rate_limited_uuids:
+                todo_file = todos_dir / f"{session_uuid}-agent-{session_uuid}.json"
+                try:
+                    st = todo_file.stat()
+                    if st.st_size <= 2:
+                        todo_file.unlink()
+                        deleted += 1
+                except OSError:
+                    pass  # file doesn't exist or inaccessible
+
+        # 3. Debug transcript files — by UUID correlation with timestamp guard
+        #    No size heuristic: the gap between rate-limited (12-14 KB) and
+        #    successful (26 KB+) is too narrow.  The timestamp guard defends
+        #    against the (theoretical) case of UUID reuse across sessions.
+        debug_dir = claude_dir / "debug"
+        if debug_dir.is_dir() and rate_limited_uuids:
+            for session_uuid in rate_limited_uuids:
+                debug_file = debug_dir / f"{session_uuid}.txt"
+                try:
+                    st = debug_file.stat()
+                    if st.st_mtime >= cutoff:
+                        debug_file.unlink()
+                        deleted += 1
+                except OSError:
+                    pass  # file doesn't exist or inaccessible
+
+        # 4. Telemetry failed event files — by UUID correlation
+        #    Pattern: 1p_failed_events.<session_uuid>.<other_uuid>.json
+        telemetry_dir = claude_dir / "telemetry"
+        if telemetry_dir.is_dir() and rate_limited_uuids:
+            for session_uuid in rate_limited_uuids:
+                for f in telemetry_dir.glob(f"1p_failed_events.{session_uuid}.*.json"):
+                    try:
+                        f.unlink()
+                        deleted += 1
+                    except OSError:
+                        pass
+
+        if deleted:
+            prompt.add_log(f"Cleaned up {deleted} rate-limit artifact(s)")
+            print(f"[cleanup] Removed {deleted} rate-limit artifact(s)")
 
     def _format_duration(self, seconds: float) -> str:
         """Format duration in seconds to human readable format."""

--- a/src/claude_code_queue/queue_manager.py
+++ b/src/claude_code_queue/queue_manager.py
@@ -388,7 +388,15 @@ class QueueManager:
             print(f"Warning: artifact cleanup failed: {e}")
 
     def _do_cleanup_rate_limit_artifacts(self, prompt: QueuedPrompt) -> None:
-        """Inner implementation — may raise; caller catches all exceptions."""
+        """Inner implementation — may raise; caller catches all exceptions.
+
+        IMPORTANT: This method relies on Claude Code's internal file layout under
+        ~/.claude/ (projects/, todos/, debug/, telemetry/). This is undocumented
+        internal structure that may change across Claude Code versions. If the
+        layout changes, cleanup will silently stop working (safe — no data loss).
+        The path encoding (resolved.replace("/", "-")) mirrors Claude Code's
+        current project directory naming convention.
+        """
         cutoff = prompt.last_executed.timestamp()
         claude_dir = Path.home() / ".claude"
         deleted = 0

--- a/src/claude_code_queue/skills/queue/SKILL.md
+++ b/src/claude_code_queue/skills/queue/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: queue
+description: >
+  Use when the user wants to queue a task for Claude Code, add prompts to
+  claude-queue, create prompt template files with YAML frontmatter, check
+  queue status, manage the prompt bank, process batch jobs, or when a task
+  is complex enough that it may hit API rate limits and should run
+  automatically with retry. Triggers on: "queue this", "add to queue",
+  "run later", "rate limit", "prompt bank", "save as template",
+  "batch of tasks", "claude-queue".
+allowed-tools: [Bash, Read, Glob]
+argument-hint: "[task description or subcommand]"
+disable-model-invocation: false
+---
+
+# Claude Queue Skill
+
+`claude-queue` queues prompts for Claude Code with automatic rate-limit
+retry. Use it proactively when tasks are complex, rate-limit-prone, or
+when the user asks to queue something.
+
+## When to Proactively Suggest Queuing
+
+Suggest using claude-queue when you notice:
+- The task involves many sequential tool calls that may hit the usage limit
+- The user says "run this later" or "I'll come back to this"
+- The user describes a batch of similar tasks (multiple files, features, etc.)
+- A rate limit was already hit in this session
+
+Example: "This refactor spans many files and may hit API limits midway.
+Want me to queue it with `claude-queue` so it retries automatically?"
+
+## Core Commands
+
+```bash
+# Quick add (short prompts, no context files needed)
+claude-queue add "Fix the auth bug" --priority 1 --working-dir /path/to/project
+
+# Create a detailed template file (complex prompts with context)
+claude-queue template task-name --priority 2
+
+# Check queue
+claude-queue status --detailed
+claude-queue list --status queued
+
+# Start the daemon (runs prompts, auto-retries on rate limit)
+claude-queue start
+
+# Cancel a queued prompt
+claude-queue cancel <prompt-id>
+```
+
+## Prompt Template Format
+
+Template files live at `~/.claude-queue/queue/task-name.md`:
+
+```markdown
+---
+priority: 0
+working_directory: /absolute/path/to/project
+context_files:
+  - src/relevant-file.py
+  - tests/test_relevant.py
+max_retries: 3
+estimated_tokens: null
+---
+
+# Task Title
+
+Clear, self-contained description of what Claude Code should do.
+Write as if there is no prior conversation context.
+
+## Context
+
+Background, constraints, or requirements.
+
+## Expected Output
+
+What should be delivered when done.
+```
+
+### Frontmatter Fields
+
+| Field | Notes |
+|---|---|
+| `priority` | **0 = highest**. Lower number executes first. |
+| `working_directory` | Absolute path. Use the actual project path from context. |
+| `context_files` | Paths relative to `working_directory`. Only include files that exist. |
+| `max_retries` | Total attempts: `3` = 3 total, `-1` = unlimited, `1` = no retry. Rate-limit retries and failures share this counter. |
+| `estimated_tokens` | Optional hint; set `null` if unknown. |
+
+### Priority Guidelines
+
+- `0` — critical / blocks other work
+- `1` — high priority (default for explicit user requests)
+- `2` — normal work
+- `5+` — background / batch jobs
+
+## Deciding: `add` vs. Template File
+
+**Use `claude-queue add`** when:
+- Prompt is short (~200 chars or less)
+- No context files needed
+- Single, clear action
+
+**Use a template file** when:
+- Multi-step task needing structured instructions
+- Context files should be attached
+- The user will want to review or edit before running
+
+For template files: construct the content and either run
+`claude-queue template task-name` and show the user what to paste in, or
+write the YAML+markdown content directly and tell the user to save it to
+`~/.claude-queue/queue/task-name.md`.
+
+## Template Bank (Reusable Templates)
+
+```bash
+claude-queue bank save daily-docs      # Create template in bank
+claude-queue bank list                  # List saved templates
+claude-queue bank use daily-docs        # Copy to active queue with new ID
+claude-queue bank delete daily-docs     # Delete from bank
+```
+
+Bank templates live at `~/.claude-queue/bank/` and use the same YAML
+frontmatter format. `bank use` copies them to the active queue —
+templates themselves never execute directly.
+
+## Batch Processing
+
+For running the same task across many inputs:
+
+```bash
+claude-queue batch generate my-template --data entries.csv
+claude-queue batch generate my-template --data entries.csv --dry-run
+claude-queue batch variables my-template    # list {{placeholders}} in template
+claude-queue batch validate my-template --data entries.csv
+```
+
+Batch templates use `{{variable}}` placeholders that match CSV column names:
+
+```markdown
+---
+priority: 2
+working_directory: /path/to/project
+context_files: []
+max_retries: 3
+estimated_tokens: null
+---
+
+Refactor `{{filename}}` located at `{{filepath}}`:
+- Update all calls from old_api() to new_api()
+- Preserve existing tests
+```
+
+## Queue Directory Layout
+
+```
+~/.claude-queue/
+├── queue/           # Active prompts (daemon reads these)
+├── completed/       # Successfully finished
+├── failed/          # Exhausted max_retries
+├── bank/            # Saved reusable templates
+└── queue-state.json
+```
+
+## Key Behavior Notes
+
+**`--dangerously-skip-permissions`**: Passed to `claude` by default so the
+daemon runs unattended. To disable interactive permission prompts:
+`claude-queue start --no-skip-permissions`.
+
+**At-least-once semantics**: If the daemon crashes mid-execution, the task
+reruns on restart. Prompt users to design queued tasks to be idempotent
+(safe to run twice) — especially for actions like "send email", "open PR",
+"create payment", etc.
+
+**Always suggest** running `claude-queue status --detailed` before starting
+the daemon so the user can review what will execute.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,15 @@ Shared fixtures for claude-code-queue test suite.
 """
 
 import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "llm_eval: marks tests that call the Anthropic API (requires ANTHROPIC_API_KEY)",
+    )
+
+
 from claude_code_queue.models import QueuedPrompt, QueueState, PromptStatus
 from claude_code_queue.storage import QueueStorage
 from claude_code_queue.claude_interface import ClaudeCodeInterface

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,504 @@
+"""Tests for batch template generation."""
+
+import csv
+import textwrap
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_code_queue.batch import (
+    extract_variables,
+    generate_batch_jobs,
+    read_data_file,
+    render_template,
+    resolve_template_path,
+    validate_batch,
+)
+from claude_code_queue.storage import QueueStorage
+
+
+# --- extract_variables ---
+
+
+class TestExtractVariables:
+    def test_single_variable(self):
+        assert extract_variables("Hello {{name}}") == {"name"}
+
+    def test_multiple_variables(self):
+        assert extract_variables("{{a}} and {{b}}") == {"a", "b"}
+
+    def test_duplicate_variables(self):
+        assert extract_variables("{{x}} then {{x}} again") == {"x"}
+
+    def test_no_variables(self):
+        assert extract_variables("plain text") == set()
+
+    def test_variables_in_yaml_frontmatter(self):
+        text = "---\nworking_directory: /src/{{project}}\n---\n\n{{task}}"
+        assert extract_variables(text) == {"project", "task"}
+
+    def test_underscores_in_variable_names(self):
+        assert extract_variables("{{my_var_1}}") == {"my_var_1"}
+
+    def test_empty_string(self):
+        assert extract_variables("") == set()
+
+    def test_single_braces_ignored(self):
+        """Single curly braces (e.g. JSON/code) are not treated as variables."""
+        assert extract_variables('{"key": {value}}') == set()
+
+    def test_triple_braces_extracts_inner(self):
+        # {{{var}}} should find "var" — the outer braces are literal
+        result = extract_variables("{{{var}}}")
+        assert "var" in result
+
+
+# --- render_template ---
+
+
+class TestRenderTemplate:
+    def test_basic_substitution(self):
+        result = render_template("Hello {{name}}", {"name": "world"})
+        assert result == "Hello world"
+
+    def test_multiple_variables(self):
+        result = render_template("{{a}} + {{b}}", {"a": "1", "b": "2"})
+        assert result == "1 + 2"
+
+    def test_repeated_variable(self):
+        result = render_template("{{x}} and {{x}}", {"x": "yes"})
+        assert result == "yes and yes"
+
+    def test_unreplaced_variable_raises(self):
+        with pytest.raises(ValueError, match="Unreplaced template variables"):
+            render_template("{{a}} {{b}}", {"a": "hello"})
+
+    def test_extra_values_ignored(self):
+        result = render_template("{{a}}", {"a": "1", "b": "2"})
+        assert result == "1"
+
+    def test_substitution_in_yaml(self):
+        template = "---\nworking_directory: /src/{{project}}\n---\n\nDo {{task}}"
+        result = render_template(template, {"project": "volk", "task": "review"})
+        assert "/src/volk" in result
+        assert "Do review" in result
+
+    def test_empty_value_substitution(self):
+        result = render_template("prefix-{{x}}-suffix", {"x": ""})
+        assert result == "prefix--suffix"
+
+    def test_value_with_special_chars(self):
+        result = render_template("file: {{name}}", {"name": "test (1).h"})
+        assert result == "file: test (1).h"
+
+
+# --- read_data_file ---
+
+
+class TestReadDataFile:
+    def test_csv_comma(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name,age\nalice,30\nbob,25\n")
+        columns, rows = read_data_file(csv_file)
+        assert columns == ["name", "age"]
+        assert len(rows) == 2
+        assert rows[0]["name"] == "alice"
+        assert rows[1]["age"] == "25"
+
+    def test_tsv(self, tmp_path):
+        tsv_file = tmp_path / "data.tsv"
+        tsv_file.write_text("name\tage\nalice\t30\nbob\t25\n")
+        columns, rows = read_data_file(tsv_file)
+        assert columns == ["name", "age"]
+        assert len(rows) == 2
+
+    def test_single_column(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("kernel\nvolk_a.h\nvolk_b.h\nvolk_c.h\n")
+        columns, rows = read_data_file(csv_file)
+        assert columns == ["kernel"]
+        assert len(rows) == 3
+
+    def test_empty_data(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name,age\n")
+        columns, rows = read_data_file(csv_file)
+        assert columns == ["name", "age"]
+        assert len(rows) == 0
+
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_data_file(tmp_path / "nonexistent.csv")
+
+    def test_semicolon_delimiter(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name;age\nalice;30\nbob;25\n")
+        columns, rows = read_data_file(csv_file)
+        assert columns == ["name", "age"]
+        assert len(rows) == 2
+        assert rows[0]["name"] == "alice"
+        assert rows[1]["age"] == "25"
+
+    def test_pipe_delimiter(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name|age\nalice|30\nbob|25\n")
+        columns, rows = read_data_file(csv_file)
+        assert columns == ["name", "age"]
+        assert len(rows) == 2
+        assert rows[0]["name"] == "alice"
+
+    def test_sniffer_fallback_to_comma(self, tmp_path):
+        """When csv.Sniffer.sniff raises csv.Error, fall back to comma."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name,age\nalice,30\nbob,25\n")
+        with patch("csv.Sniffer.sniff", side_effect=csv.Error("cannot sniff")):
+            columns, rows = read_data_file(csv_file)
+        assert columns == ["name", "age"]
+        assert len(rows) == 2
+        assert rows[0]["name"] == "alice"
+
+
+# --- validate_batch ---
+
+
+class TestValidateBatch:
+    def test_perfect_match(self):
+        errors, warnings = validate_batch({"a", "b"}, ["a", "b"])
+        assert errors == []
+        assert warnings == []
+
+    def test_missing_variable(self):
+        errors, warnings = validate_batch({"a", "b"}, ["a"])
+        assert len(errors) == 1
+        assert "b" in errors[0]
+
+    def test_extra_column_warning(self):
+        errors, warnings = validate_batch({"a"}, ["a", "b"])
+        assert errors == []
+        assert len(warnings) == 1
+        assert "b" in warnings[0]
+
+    def test_both_missing_and_extra(self):
+        errors, warnings = validate_batch({"a", "b"}, ["a", "c"])
+        assert len(errors) == 1  # b missing
+        assert len(warnings) == 1  # c extra
+
+    def test_empty_template_vars(self):
+        errors, warnings = validate_batch(set(), ["a"])
+        assert errors == []
+        assert len(warnings) == 1
+
+    def test_empty_columns(self):
+        errors, warnings = validate_batch({"a"}, [])
+        assert len(errors) == 1
+        assert warnings == []
+
+
+# --- resolve_template_path ---
+
+
+class TestResolveTemplatePath:
+    def test_direct_file_path(self, tmp_path):
+        template = tmp_path / "my-template.md"
+        template.write_text("content")
+        result = resolve_template_path(str(template), tmp_path / "bank")
+        assert result == template
+
+    def test_bank_name(self, tmp_path):
+        bank_dir = tmp_path / "bank"
+        bank_dir.mkdir()
+        template = bank_dir / "review.md"
+        template.write_text("content")
+        result = resolve_template_path("review", bank_dir)
+        assert result == template
+
+    def test_not_found_raises(self, tmp_path):
+        bank_dir = tmp_path / "bank"
+        bank_dir.mkdir()
+        with pytest.raises(FileNotFoundError, match="not found"):
+            resolve_template_path("nonexistent", bank_dir)
+
+    def test_direct_path_preferred_over_bank(self, tmp_path):
+        """If a file exists at the direct path, use it even if bank also has it."""
+        bank_dir = tmp_path / "bank"
+        bank_dir.mkdir()
+        (bank_dir / "tmpl.md").write_text("bank version")
+        direct = tmp_path / "tmpl.md"
+        direct.write_text("direct version")
+        result = resolve_template_path(str(direct), bank_dir)
+        assert result == direct
+
+
+# --- generate_batch_jobs ---
+
+
+TEMPLATE_CONTENT = textwrap.dedent("""\
+    ---
+    priority: 5
+    working_directory: /src/{{project}}
+    context_files: []
+    max_retries: 2
+    estimated_tokens: 1000
+    ---
+
+    Review the file {{filename}} in project {{project}}.
+""")
+
+
+class TestGenerateBatchJobs:
+    def _make_template_and_csv(self, tmp_path, template_text, csv_text):
+        template_path = tmp_path / "template.md"
+        template_path.write_text(template_text)
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text(csv_text)
+        return template_path, csv_path
+
+    def test_basic_generation(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,kernel_a.h\nvolk,kernel_b.h\n",
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+
+        assert len(prompts) == 2
+        assert "kernel_a.h" in prompts[0].content
+        assert "kernel_b.h" in prompts[1].content
+        assert prompts[0].working_directory == "/src/volk"
+        assert prompts[1].working_directory == "/src/volk"
+
+    def test_unique_ids(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\na,x.h\nb,y.h\nc,z.h\n",
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+        ids = [p.id for p in prompts]
+        assert len(set(ids)) == 3  # all unique
+
+    def test_default_priority_from_template(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\nvolk,b.h\n",
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+        assert prompts[0].priority == 5
+        assert prompts[1].priority == 5
+
+    def test_base_priority_override(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\nvolk,b.h\nvolk,c.h\n",
+        )
+
+        prompts = generate_batch_jobs(
+            template_path, csv_path, storage, base_priority=10, priority_step=5
+        )
+        assert prompts[0].priority == 10
+        assert prompts[1].priority == 15
+        assert prompts[2].priority == 20
+
+    def test_dry_run_no_files_written(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\n",
+        )
+
+        prompts = generate_batch_jobs(
+            template_path, csv_path, storage, dry_run=True
+        )
+        assert len(prompts) == 1
+        # Queue directory should be empty (no files written)
+        queue_files = list(storage.queue_dir.glob("*.md"))
+        assert len(queue_files) == 0
+
+    def test_files_written_to_queue(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\nvolk,b.h\n",
+        )
+
+        generate_batch_jobs(template_path, csv_path, storage)
+        queue_files = list(storage.queue_dir.glob("*.md"))
+        assert len(queue_files) == 2
+
+    def test_missing_variable_in_csv_raises(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project\nvolk\n",  # missing 'filename' column
+        )
+
+        with pytest.raises(ValueError, match="not found in data"):
+            generate_batch_jobs(template_path, csv_path, storage)
+
+    def test_max_retries_preserved(self, tmp_path):
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\n",
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+        assert prompts[0].max_retries == 2
+
+    def test_single_column_csv(self, tmp_path):
+        """Template with one variable and a single-column CSV."""
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template = textwrap.dedent("""\
+            ---
+            priority: 0
+            working_directory: .
+            max_retries: 3
+            ---
+
+            Process {{item}}
+        """)
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path, template, "item\nalpha\nbeta\ngamma\n"
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+        assert len(prompts) == 3
+        assert "alpha" in prompts[0].content
+        assert "beta" in prompts[1].content
+        assert "gamma" in prompts[2].content
+
+    def test_working_directory_substitution(self, tmp_path):
+        """Variables in YAML frontmatter values are substituted."""
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nmyproject,file.py\n",
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+        assert prompts[0].working_directory == "/src/myproject"
+
+    def test_execution_state_fully_reset(self, tmp_path):
+        """Every state field is reset to a clean initial value per generated job."""
+        from claude_code_queue.models import PromptStatus
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\nvolk,b.h\n",
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+
+        for prompt in prompts:
+            assert prompt.status == PromptStatus.QUEUED
+            assert prompt.retry_count == 0
+            assert prompt.execution_log == ""
+            assert prompt.last_executed is None
+            assert prompt.rate_limited_at is None
+            assert prompt.reset_time is None
+
+    def test_created_at_is_recent(self, tmp_path):
+        """Each generated job has a fresh created_at timestamp."""
+        from datetime import timedelta
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\nvolk,b.h\n",
+        )
+
+        before = datetime.now()
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+        after = datetime.now()
+
+        for prompt in prompts:
+            assert isinstance(prompt.created_at, datetime)
+            assert before - timedelta(seconds=1) <= prompt.created_at <= after + timedelta(seconds=1)
+
+    def test_id_is_eight_characters(self, tmp_path):
+        """Each generated job receives an 8-character UUID prefix as its ID."""
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\nvolk,b.h\nvolk,c.h\n",
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+        for prompt in prompts:
+            assert len(prompt.id) == 8
+
+    def test_empty_csv_returns_empty_list(self, tmp_path):
+        """A CSV with only a header row produces no jobs and no files."""
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\n",  # header only, no data rows
+        )
+
+        prompts = generate_batch_jobs(template_path, csv_path, storage)
+
+        assert prompts == []
+        queue_files = list(storage.queue_dir.glob("*.md"))
+        assert len(queue_files) == 0
+
+    def test_base_priority_zero_is_applied(self, tmp_path):
+        """base_priority=0 (falsy) overrides template priority — guards against 'if base_priority:' bug."""
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\n",
+        )
+
+        prompts = generate_batch_jobs(
+            template_path, csv_path, storage, base_priority=0
+        )
+        assert prompts[0].priority == 0
+
+    def test_priority_step_zero_all_same_priority(self, tmp_path):
+        """priority_step=0 means every job gets exactly base_priority."""
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename\nvolk,a.h\nvolk,b.h\nvolk,c.h\n",
+        )
+
+        prompts = generate_batch_jobs(
+            template_path, csv_path, storage, base_priority=10, priority_step=0
+        )
+        assert all(p.priority == 10 for p in prompts)
+
+    def test_dry_run_with_extra_columns_still_generates(self, tmp_path):
+        """Extra CSV columns are a warning, not an error; generation still proceeds."""
+        storage = QueueStorage(storage_dir=str(tmp_path / "storage"))
+        template_path, csv_path = self._make_template_and_csv(
+            tmp_path,
+            TEMPLATE_CONTENT,
+            "project,filename,extra_col\nvolk,a.h,ignored\n",
+        )
+
+        prompts = generate_batch_jobs(
+            template_path, csv_path, storage, dry_run=True
+        )
+        assert len(prompts) == 1
+        assert "a.h" in prompts[0].content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -936,3 +936,269 @@ class TestPromptBoxCommand:
         assert code == 0
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == expected_binary
+
+
+# ===========================================================================
+# `batch` Command
+# ===========================================================================
+
+def _make_mock_prompt(priority=5, content="Review file.h", working_directory="/src"):
+    """Build a minimal QueuedPrompt-like mock for batch tests."""
+    p = MagicMock(spec=QueuedPrompt)
+    p.priority = priority
+    p.content = content
+    p.working_directory = working_directory
+    return p
+
+
+class TestBatchNoSubcommand:
+    def test_batch_no_subcommand_returns_1(self, capsys):
+        with patch("sys.argv", ["claude-queue", "batch"]):
+            with patch("claude_code_queue.cli.QueueStorage"):
+                code = main()
+        assert code == 1
+        assert "No batch operation specified" in capsys.readouterr().out
+
+
+class TestBatchGenerate:
+    def _run(self, tmp_path, *extra_args, prompts=None, resolve_side_effect=None,
+             generate_side_effect=None):
+        """Run `claude-queue batch generate tmpl --data data.csv [extra_args]`.
+
+        Creates a real data file so the is_file() check passes.
+        Patches resolve_template_path and generate_batch_jobs.
+        """
+        data_file = tmp_path / "data.csv"
+        data_file.write_text("project,filename\nvolk,a.h\n")
+
+        template_file = tmp_path / "template.md"
+        template_file.write_text("---\npriority: 5\n---\n\nhello")
+
+        mock_storage = MagicMock()
+        mock_storage.bank_dir = tmp_path / "bank"
+
+        if prompts is None:
+            prompts = [_make_mock_prompt(priority=10), _make_mock_prompt(priority=15)]
+
+        argv = [
+            "claude-queue", "batch", "generate", str(template_file),
+            "--data", str(data_file),
+        ] + list(extra_args)
+
+        with patch("sys.argv", argv):
+            with patch("claude_code_queue.cli.QueueStorage", return_value=mock_storage):
+                with patch(
+                    "claude_code_queue.cli.resolve_template_path",
+                    side_effect=resolve_side_effect or (lambda ref, bank: template_file),
+                ):
+                    with patch(
+                        "claude_code_queue.cli.generate_batch_jobs",
+                        side_effect=generate_side_effect or (lambda **kw: prompts),
+                    ):
+                        code = main()
+        return code
+
+    def test_batch_generate_success(self, tmp_path, capsys):
+        code = self._run(tmp_path)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Generated 2 job(s)" in out
+
+    def test_batch_generate_success_shows_priority_range(self, tmp_path, capsys):
+        prompts = [_make_mock_prompt(priority=10), _make_mock_prompt(priority=15)]
+        self._run(tmp_path, prompts=prompts)
+        out = capsys.readouterr().out
+        assert "10" in out
+        assert "15" in out
+
+    def test_batch_generate_single_job_priority_range(self, tmp_path, capsys):
+        prompts = [_make_mock_prompt(priority=5)]
+        self._run(tmp_path, prompts=prompts)
+        out = capsys.readouterr().out
+        assert "1 job(s)" in out
+        # min and max are both 5
+        assert out.count("5") >= 2
+
+    def test_batch_generate_dry_run_output(self, tmp_path, capsys):
+        prompts = [_make_mock_prompt(priority=7, content="Review x.h in project")]
+        code = self._run(tmp_path, "--dry-run", prompts=prompts)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Dry run" in out
+        assert "would generate" in out
+
+    def test_batch_generate_data_file_not_found(self, tmp_path, capsys):
+        """Missing data file → return 1 before touching template or generate."""
+        with patch("sys.argv", [
+            "claude-queue", "batch", "generate", "tmpl",
+            "--data", str(tmp_path / "nonexistent.csv"),
+        ]):
+            with patch("claude_code_queue.cli.QueueStorage"):
+                code = main()
+        assert code == 1
+        assert "Data file not found" in capsys.readouterr().out
+
+    def test_batch_generate_template_not_found(self, tmp_path, capsys):
+        code = self._run(
+            tmp_path,
+            resolve_side_effect=FileNotFoundError("Template 'tmpl' not found"),
+        )
+        assert code == 1
+        assert "Error:" in capsys.readouterr().out
+
+    def test_batch_generate_validation_error(self, tmp_path, capsys):
+        code = self._run(
+            tmp_path,
+            generate_side_effect=ValueError("Template variables not found in data"),
+        )
+        assert code == 1
+        assert "Error:" in capsys.readouterr().out
+
+
+class TestBatchValidate:
+    def _run(self, tmp_path, template_text, csv_text, *extra_args,
+             resolve_side_effect=None):
+        """Run `claude-queue batch validate tmpl --data data.csv`."""
+        template_file = tmp_path / "template.md"
+        template_file.write_text(template_text)
+
+        data_file = tmp_path / "data.csv"
+        data_file.write_text(csv_text)
+
+        mock_storage = MagicMock()
+        mock_storage.bank_dir = tmp_path / "bank"
+
+        argv = [
+            "claude-queue", "batch", "validate", str(template_file),
+            "--data", str(data_file),
+        ] + list(extra_args)
+
+        with patch("sys.argv", argv):
+            with patch("claude_code_queue.cli.QueueStorage", return_value=mock_storage):
+                with patch(
+                    "claude_code_queue.cli.resolve_template_path",
+                    side_effect=resolve_side_effect or (lambda ref, bank: template_file),
+                ):
+                    code = main()
+        return code
+
+    def test_batch_validate_valid_returns_0(self, tmp_path, capsys):
+        code = self._run(
+            tmp_path,
+            "---\npriority: 0\n---\n\nHello {{name}}",
+            "name\nalice\n",
+        )
+        assert code == 0
+        assert "Valid:" in capsys.readouterr().out
+
+    def test_batch_validate_with_warnings_returns_0(self, tmp_path, capsys):
+        code = self._run(
+            tmp_path,
+            "---\npriority: 0\n---\n\nHello {{name}}",
+            "name,extra\nalice,unused\n",
+        )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "Valid with warnings" in out
+
+    def test_batch_validate_with_errors_returns_1(self, tmp_path, capsys):
+        """Template references {{name}} but CSV only has 'other' column → error."""
+        code = self._run(
+            tmp_path,
+            "---\npriority: 0\n---\n\nHello {{name}}",
+            "other\nval\n",
+        )
+        assert code == 1
+        assert "Error" in capsys.readouterr().out
+
+    def test_batch_validate_data_file_not_found(self, tmp_path, capsys):
+        template_file = tmp_path / "t.md"
+        template_file.write_text("hello")
+        mock_storage = MagicMock()
+        mock_storage.bank_dir = tmp_path / "bank"
+
+        with patch("sys.argv", [
+            "claude-queue", "batch", "validate", str(template_file),
+            "--data", str(tmp_path / "nonexistent.csv"),
+        ]):
+            with patch("claude_code_queue.cli.QueueStorage", return_value=mock_storage):
+                code = main()
+        assert code == 1
+        assert "Data file not found" in capsys.readouterr().out
+
+    def test_batch_validate_template_not_found(self, tmp_path, capsys):
+        data_file = tmp_path / "data.csv"
+        data_file.write_text("name\nalice\n")
+        mock_storage = MagicMock()
+        mock_storage.bank_dir = tmp_path / "bank"
+
+        with patch("sys.argv", [
+            "claude-queue", "batch", "validate", "nonexistent",
+            "--data", str(data_file),
+        ]):
+            with patch("claude_code_queue.cli.QueueStorage", return_value=mock_storage):
+                with patch(
+                    "claude_code_queue.cli.resolve_template_path",
+                    side_effect=FileNotFoundError("not found"),
+                ):
+                    code = main()
+        assert code == 1
+        assert "Error:" in capsys.readouterr().out
+
+    def test_batch_validate_output_shows_row_count(self, tmp_path, capsys):
+        self._run(
+            tmp_path,
+            "---\npriority: 0\n---\n\nHello {{name}}",
+            "name\nalice\nbob\ncharlie\n",
+        )
+        out = capsys.readouterr().out
+        assert "3 row(s)" in out
+
+
+class TestBatchVariables:
+    def _run(self, tmp_path, template_text, resolve_side_effect=None):
+        template_file = tmp_path / "template.md"
+        template_file.write_text(template_text)
+
+        mock_storage = MagicMock()
+        mock_storage.bank_dir = tmp_path / "bank"
+
+        with patch("sys.argv", ["claude-queue", "batch", "variables", str(template_file)]):
+            with patch("claude_code_queue.cli.QueueStorage", return_value=mock_storage):
+                with patch(
+                    "claude_code_queue.cli.resolve_template_path",
+                    side_effect=resolve_side_effect or (lambda ref, bank: template_file),
+                ):
+                    code = main()
+        return code
+
+    def test_batch_variables_lists_variables(self, tmp_path, capsys):
+        code = self._run(tmp_path, "---\npriority: 0\n---\n\nReview {{filename}} in {{project}}")
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "{{filename}}" in out
+        assert "{{project}}" in out
+
+    def test_batch_variables_no_variables(self, tmp_path, capsys):
+        code = self._run(tmp_path, "---\npriority: 0\n---\n\nNo placeholders here")
+        assert code == 0
+        assert "No variables found" in capsys.readouterr().out
+
+    def test_batch_variables_template_not_found(self, tmp_path, capsys):
+        mock_storage = MagicMock()
+        mock_storage.bank_dir = tmp_path / "bank"
+
+        with patch("sys.argv", ["claude-queue", "batch", "variables", "nonexistent"]):
+            with patch("claude_code_queue.cli.QueueStorage", return_value=mock_storage):
+                with patch(
+                    "claude_code_queue.cli.resolve_template_path",
+                    side_effect=FileNotFoundError("not found"),
+                ):
+                    code = main()
+        assert code == 1
+        assert "Error:" in capsys.readouterr().out
+
+    def test_batch_variables_returns_0(self, tmp_path):
+        code = self._run(tmp_path, "---\npriority: 0\n---\n\nProcess {{item}}")
+        assert code == 0

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -1,0 +1,280 @@
+"""
+Tests for the bundled Claude Code skill — Pass SK-1.
+
+Covers:
+  - SKILL.md structural validity (YAML frontmatter, required fields)
+  - Consistency between skill documentation and the actual CLI / data model
+  - install-skill CLI command (file creation, idempotency, --force, error paths)
+"""
+
+import dataclasses
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+import claude_code_queue.cli as _cli_module
+from claude_code_queue.cli import main
+from claude_code_queue.models import QueuedPrompt
+from claude_code_queue.storage import MarkdownPromptParser
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+SKILL_PATH = (
+    Path(__file__).parent.parent
+    / "src"
+    / "claude_code_queue"
+    / "skills"
+    / "queue"
+    / "SKILL.md"
+)
+
+# Known CLI subcommands registered in cli.py.
+_CLI_SUBCOMMANDS = {
+    "start", "add", "template", "status", "cancel",
+    "list", "test", "bank", "batch", "install-skill", "prompt-box",
+}
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    """Full text of the bundled SKILL.md."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def skill_frontmatter(skill_text):
+    """Parsed YAML from the SKILL.md frontmatter block."""
+    parts = skill_text.split("---\n", 2)
+    assert len(parts) >= 3, "SKILL.md must open with a YAML frontmatter block"
+    return yaml.safe_load(parts[1])
+
+
+# ---------------------------------------------------------------------------
+# SK-001 – SK-005: SKILL.md structural validity
+# ---------------------------------------------------------------------------
+
+class TestSkillFileStructure:
+    """Verify the bundled SKILL.md is well-formed and contains required fields."""
+
+    def test_sk001_skill_md_exists_in_package(self):
+        """SK-001: SKILL.md is present at the expected package path."""
+        assert SKILL_PATH.exists(), (
+            f"Bundled SKILL.md not found at {SKILL_PATH}. "
+            "Was 'skills/**/*' added to pyproject.toml package-data?"
+        )
+
+    def test_sk002_frontmatter_is_valid_yaml(self, skill_text):
+        """SK-002: The YAML frontmatter block parses without error."""
+        parts = skill_text.split("---\n", 2)
+        assert len(parts) >= 3, "SKILL.md must have an opening --- block"
+        yaml.safe_load(parts[1])  # raises yaml.YAMLError on invalid YAML
+
+    def test_sk003_required_field_name(self, skill_frontmatter):
+        """SK-003: 'name' field is present and set to 'queue'."""
+        assert "name" in skill_frontmatter
+        assert skill_frontmatter["name"] == "queue"
+
+    def test_sk004_required_field_description(self, skill_frontmatter):
+        """SK-004: 'description' field is present and non-trivial."""
+        assert "description" in skill_frontmatter
+        assert len(str(skill_frontmatter["description"])) > 20
+
+    def test_sk005_allowed_tools_includes_bash(self, skill_frontmatter):
+        """SK-005: 'allowed-tools' includes Bash so Claude can run claude-queue."""
+        assert "allowed-tools" in skill_frontmatter
+        tools = skill_frontmatter["allowed-tools"]
+        tool_str = " ".join(tools) if isinstance(tools, list) else str(tools)
+        assert "Bash" in tool_str
+
+
+# ---------------------------------------------------------------------------
+# SK-006 – SK-007: Consistency between SKILL.md and the codebase
+# ---------------------------------------------------------------------------
+
+class TestSkillConsistency:
+    """Verify SKILL.md documentation matches the real CLI and data model."""
+
+    def test_sk006_commands_in_skill_match_cli_subparsers(self, skill_text):
+        """SK-006: Every 'claude-queue <sub>' in bash blocks is a real CLI subcommand."""
+        bash_blocks = re.findall(r"```bash\n(.*?)```", skill_text, re.DOTALL)
+        mentioned = set()
+        for block in bash_blocks:
+            for line in block.splitlines():
+                line = line.strip().lstrip("# ")
+                m = re.match(r"claude-queue\s+([\w-]+)", line)
+                if m:
+                    mentioned.add(m.group(1))
+
+        for sub in mentioned:
+            assert sub in _CLI_SUBCOMMANDS, (
+                f"Command 'claude-queue {sub}' appears in SKILL.md "
+                f"but is not a registered CLI subcommand. "
+                f"Known subcommands: {sorted(_CLI_SUBCOMMANDS)}"
+            )
+
+    def test_sk007_template_frontmatter_fields_match_queued_prompt(self, skill_text):
+        """SK-007: YAML keys in the template block map to QueuedPrompt field names."""
+        # Find the first ```markdown block that starts with frontmatter
+        md_blocks = re.findall(r"```markdown\n(---\n.*?---)", skill_text, re.DOTALL)
+        assert md_blocks, "No ```markdown block with frontmatter found in SKILL.md"
+
+        # Captured block is "---\nkeys\n---"; extract just the keys section.
+        template_yaml_str = md_blocks[0].split("---\n", 2)[1].split("\n---")[0]
+        template_yaml = yaml.safe_load(template_yaml_str)
+        assert template_yaml, "Template frontmatter parsed as empty"
+
+        prompt_fields = {f.name for f in dataclasses.fields(QueuedPrompt)}
+        for key in template_yaml:
+            assert key in prompt_fields, (
+                f"Template field '{key}' in SKILL.md is not a QueuedPrompt field. "
+                f"Valid fields: {sorted(prompt_fields)}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# SK-008: Template round-trip through storage parser
+# ---------------------------------------------------------------------------
+
+class TestSkillTemplateParseable:
+    """Verify the SKILL.md prompt template is accepted by the real storage parser."""
+
+    def test_sk008_template_parses_without_error(self, skill_text, tmp_path):
+        """SK-008: A file written in the SKILL.md template format parses correctly."""
+        # Extract the first full ```markdown block (frontmatter + body)
+        match = re.search(
+            r"```markdown\n(---\n.*?---\n.*?)```",
+            skill_text,
+            re.DOTALL,
+        )
+        assert match, "No complete ```markdown template block found in SKILL.md"
+
+        # Substitute the placeholder working_directory with a real path
+        content = match.group(1).replace(
+            "/absolute/path/to/project", str(tmp_path)
+        )
+        # Remove placeholder context_files entries (parser accepts but may warn)
+        content = re.sub(
+            r"context_files:\n(  - .*\n)+",
+            "context_files: []\n",
+            content,
+        )
+
+        template_file = tmp_path / "testid-skill-template.md"
+        template_file.write_text(content, encoding="utf-8")
+
+        parser = MarkdownPromptParser()
+        prompt = parser.parse_prompt_file(template_file)
+
+        assert prompt is not None, "MarkdownPromptParser returned None for a valid template"
+        assert prompt.priority == 0
+        assert prompt.max_retries == 3
+        assert prompt.working_directory == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# SK-009 – SK-018: install-skill CLI command
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def skill_home(tmp_path, monkeypatch):
+    """
+    Redirect Path.home() → tmp_path for the duration of one test.
+
+    install-skill writes to Path.home() / ".claude" / "skills" / "queue" / "SKILL.md".
+    By redirecting home, all file operations land in the test's temporary directory
+    without touching the real ~/.claude/ directory.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return tmp_path
+
+
+class TestInstallSkillCommand:
+    """Unit tests for 'claude-queue install-skill'."""
+
+    @staticmethod
+    def _run(*extra_args):
+        """Invoke main() with sys.argv configured for install-skill."""
+        with patch("sys.argv", ["claude-queue", "install-skill"] + list(extra_args)):
+            return main()
+
+    @staticmethod
+    def _dest(home: Path) -> Path:
+        return home / ".claude" / "skills" / "queue" / "SKILL.md"
+
+    def test_sk009_fresh_install_returns_0(self, skill_home):
+        """SK-009: First installation exits with code 0."""
+        assert self._run() == 0
+
+    def test_sk010_fresh_install_creates_file(self, skill_home):
+        """SK-010: SKILL.md is written to ~/.claude/skills/queue/."""
+        self._run()
+        assert self._dest(skill_home).exists()
+
+    def test_sk011_fresh_install_creates_parent_dirs(self, skill_home):
+        """SK-011: Intermediate directories are created as needed."""
+        self._run()
+        assert (skill_home / ".claude" / "skills" / "queue").is_dir()
+
+    def test_sk012_fresh_install_content_matches_bundled(self, skill_home):
+        """SK-012: Written file content matches the bundled SKILL.md exactly."""
+        self._run()
+        written = self._dest(skill_home).read_text(encoding="utf-8")
+        bundled = SKILL_PATH.read_text(encoding="utf-8")
+        assert written == bundled
+
+    def test_sk013_fresh_install_prints_destination(self, skill_home, capsys):
+        """SK-013: Success message includes the destination path."""
+        self._run()
+        out = capsys.readouterr().out
+        assert str(self._dest(skill_home)) in out
+
+    def test_sk014_already_installed_returns_1(self, skill_home):
+        """SK-014: A second install (without --force) exits with code 1."""
+        self._run()
+        assert self._run() == 1
+
+    def test_sk015_already_installed_warns_user(self, skill_home, capsys):
+        """SK-015: Warning message mentions 'already installed' and '--force'."""
+        self._run()
+        capsys.readouterr()  # clear first install output
+        self._run()
+        out = capsys.readouterr().out
+        assert "already installed" in out.lower()
+        assert "--force" in out
+
+    def test_sk016_force_overwrites_returns_0(self, skill_home):
+        """SK-016: --force on an existing install exits with code 0."""
+        self._run()
+        assert self._run("--force") == 0
+
+    def test_sk017_force_rewrites_with_bundled_content(self, skill_home):
+        """SK-017: --force replaces a modified file with the bundled version."""
+        dest = self._dest(skill_home)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("stale content", encoding="utf-8")
+
+        self._run("--force")
+
+        assert dest.read_text(encoding="utf-8") == SKILL_PATH.read_text(encoding="utf-8")
+
+    def test_sk018_missing_bundled_source_returns_1(self, skill_home, monkeypatch):
+        """SK-018: Returns 1 and prints an error if the bundled SKILL.md is missing."""
+        # Point the module's __file__ to a dir that has no skills/ alongside it
+        monkeypatch.setattr(_cli_module, "__file__", str(skill_home / "cli.py"))
+        assert self._run() == 1
+
+    def test_sk018b_missing_bundled_source_prints_error(
+        self, skill_home, monkeypatch, capsys
+    ):
+        """SK-018b: Error message is printed when bundled source is missing."""
+        monkeypatch.setattr(_cli_module, "__file__", str(skill_home / "cli.py"))
+        self._run()
+        out = capsys.readouterr().out
+        assert "not found" in out.lower() or "error" in out.lower()

--- a/tests/test_skill_integration.py
+++ b/tests/test_skill_integration.py
@@ -1,0 +1,332 @@
+"""
+Integration and LLM evaluation tests for the bundled Claude Code skill — Pass SK-2.
+
+Covers:
+  - Queue round-trip: write a file in SKILL.md template format, process via
+    QueueManager with mocked Claude, verify completion. (no API required)
+  - LLM eval: real Anthropic API calls verifying Claude behaves correctly
+    when the skill content is loaded as a system prompt. (requires
+    ANTHROPIC_API_KEY; tests are skipped when the key is absent)
+
+Run just the free tests:
+  pytest tests/test_skill_integration.py -m "not llm_eval" -v
+
+Run all tests (requires API key):
+  ANTHROPIC_API_KEY=sk-ant-... pytest tests/test_skill_integration.py -v
+"""
+
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from claude_code_queue.claude_interface import ClaudeCodeInterface
+from claude_code_queue.models import ExecutionResult, QueuedPrompt
+from claude_code_queue.queue_manager import QueueManager
+from claude_code_queue.storage import MarkdownPromptParser, QueueStorage
+
+
+# ---------------------------------------------------------------------------
+# Shared constants and fixtures
+# ---------------------------------------------------------------------------
+
+SKILL_PATH = (
+    Path(__file__).parent.parent
+    / "src"
+    / "claude_code_queue"
+    / "skills"
+    / "queue"
+    / "SKILL.md"
+)
+
+# Cheapest model for eval — deterministic enough for structural assertions.
+_EVAL_MODEL = "claude-haiku-4-5-20251001"
+
+# Decorator: skip test when ANTHROPIC_API_KEY is not present in the environment.
+llm_eval = pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set — skipping LLM eval test",
+)
+
+
+@pytest.fixture(scope="module")
+def skill_content():
+    """Full text of the bundled SKILL.md (system prompt for eval tests)."""
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def anthropic_client():
+    """Anthropic SDK client (module-scoped; stateless, safe to share)."""
+    import anthropic  # optional dependency — only imported when needed
+    return anthropic.Anthropic()
+
+
+# ---------------------------------------------------------------------------
+# SI-001: Queue round-trip (no API required)
+# ---------------------------------------------------------------------------
+
+class TestQueueRoundTrip:
+    """
+    Verify that a prompt file written in the exact format shown in SKILL.md
+    is correctly ingested, executed (with mocked Claude), and completed.
+    """
+
+    def test_si001_skill_template_format_submits_and_completes(
+        self, tmp_path, mocker
+    ):
+        """
+        SI-001: SKILL.md template format → queue → execute → completed dir.
+
+        This is the core integration test: it writes a raw .md file using the
+        same frontmatter schema documented in SKILL.md, then verifies the
+        QueueManager picks it up via _load_prompts_from_files and moves it to
+        the completed directory after a successful (mocked) execution.
+        """
+        mocker.patch.object(ClaudeCodeInterface, "_verify_claude_available")
+        mocker.patch.object(
+            ClaudeCodeInterface, "test_connection", return_value=(True, "ok")
+        )
+
+        # Write a queue file using the exact frontmatter format from SKILL.md.
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir(parents=True)
+        queue_file = queue_dir / "testid-fix-auth.md"
+        queue_file.write_text(
+            f"---\n"
+            f"priority: 1\n"
+            f"working_directory: {tmp_path}\n"
+            f"context_files: []\n"
+            f"max_retries: 3\n"
+            f"estimated_tokens: null\n"
+            f"---\n\n"
+            f"# Fix authentication bug\n\n"
+            f"Locate and fix the login bug in the auth module.\n",
+            encoding="utf-8",
+        )
+
+        manager = QueueManager(
+            storage_dir=str(tmp_path), claude_command="claude"
+        )
+        mock_result = ExecutionResult(
+            success=True,
+            output="Fixed the auth bug successfully.",
+            error="",
+            execution_time=0.5,
+        )
+
+        with patch.object(
+            manager.claude_interface, "execute_prompt", return_value=mock_result
+        ):
+            manager._process_queue_iteration()
+
+        completed = list((tmp_path / "completed").glob("*.md"))
+        assert len(completed) == 1, (
+            "Expected one completed prompt; "
+            f"found {len(completed)} in {tmp_path / 'completed'}"
+        )
+
+    def test_si002_installed_skill_content_is_readable_yaml(self, tmp_path):
+        """
+        SI-002: After install-skill writes the file, it can be re-parsed as
+        valid YAML frontmatter — a sanity check on the file-copy path.
+        """
+        from pathlib import Path as _Path
+        import claude_code_queue.cli as cli_mod
+
+        dest = tmp_path / ".claude" / "skills" / "queue" / "SKILL.md"
+
+        with patch.object(_Path, "home", return_value=tmp_path):
+            with patch("sys.argv", ["claude-queue", "install-skill"]):
+                from claude_code_queue.cli import main
+                main()
+
+        assert dest.exists()
+        text = dest.read_text(encoding="utf-8")
+        parts = text.split("---\n", 2)
+        assert len(parts) >= 3
+        parsed = yaml.safe_load(parts[1])
+        assert parsed["name"] == "queue"
+        assert "Bash" in " ".join(
+            parsed["allowed-tools"]
+            if isinstance(parsed["allowed-tools"], list)
+            else [parsed["allowed-tools"]]
+        )
+
+
+# ---------------------------------------------------------------------------
+# LLM eval tests (require ANTHROPIC_API_KEY)
+# ---------------------------------------------------------------------------
+
+class TestSkillLLMEval:
+    """
+    Evaluate Claude's behaviour when the SKILL.md content is provided as a
+    system prompt.  These tests make real Anthropic API calls and are skipped
+    when ANTHROPIC_API_KEY is not present in the environment.
+
+    Assertions are structural rather than exact-match to accommodate the
+    non-deterministic nature of LLM outputs.
+    """
+
+    @llm_eval
+    def test_si003_claude_suggests_queuing_for_complex_task(
+        self, anthropic_client, skill_content
+    ):
+        """
+        SI-003: Claude mentions claude-queue when prompted with a task likely
+        to hit API rate limits.
+        """
+        response = anthropic_client.messages.create(
+            model=_EVAL_MODEL,
+            max_tokens=512,
+            system=skill_content,
+            messages=[{
+                "role": "user",
+                "content": (
+                    "I need to refactor the authentication code across 15 files "
+                    "to use the new OAuth2 library. This will be a very large change."
+                ),
+            }],
+        )
+        text = response.content[0].text.lower()
+        assert "claude-queue" in text or "queue" in text, (
+            f"Expected Claude to mention queuing for a complex multi-file task. "
+            f"Response: {response.content[0].text!r}"
+        )
+
+    @llm_eval
+    def test_si004_claude_produces_valid_yaml_frontmatter(
+        self, anthropic_client, skill_content
+    ):
+        """
+        SI-004: Claude generates a queue template with valid, parseable YAML
+        frontmatter when asked to create a prompt file.
+        """
+        response = anthropic_client.messages.create(
+            model=_EVAL_MODEL,
+            max_tokens=1024,
+            system=skill_content,
+            messages=[{
+                "role": "user",
+                "content": (
+                    "Please create a queue template to fix the login bug in "
+                    "/home/user/myapp"
+                ),
+            }],
+        )
+        text = response.content[0].text
+
+        match = re.search(r"^---\n(.*?)\n---", text, re.DOTALL | re.MULTILINE)
+        assert match, (
+            "Expected YAML frontmatter between --- markers in Claude's response. "
+            f"Response: {text!r}"
+        )
+
+        parsed = yaml.safe_load(match.group(1))
+        assert "priority" in parsed, "Template should include 'priority' field"
+        assert "working_directory" in parsed, "Template should include 'working_directory'"
+        assert "max_retries" in parsed, "Template should include 'max_retries'"
+
+    @llm_eval
+    def test_si005_claude_template_parses_with_storage(
+        self, anthropic_client, skill_content, tmp_path
+    ):
+        """
+        SI-005: The template Claude produces is accepted by MarkdownPromptParser
+        without error — the ultimate consistency check.
+        """
+        response = anthropic_client.messages.create(
+            model=_EVAL_MODEL,
+            max_tokens=1024,
+            system=skill_content,
+            messages=[{
+                "role": "user",
+                "content": (
+                    f"Create a queue template to fix the auth bug. "
+                    f"Use working_directory: {tmp_path}"
+                ),
+            }],
+        )
+        text = response.content[0].text
+
+        # Accept the template whether Claude wraps it in ```markdown or not.
+        md_match = re.search(
+            r"```(?:markdown)?\n(---\n.*?---\n.*?)```", text, re.DOTALL
+        )
+        content = md_match.group(1) if md_match else text
+
+        template_file = tmp_path / "testid-claude-generated.md"
+        template_file.write_text(content, encoding="utf-8")
+
+        parser = MarkdownPromptParser()
+        prompt = parser.parse_prompt_file(template_file)
+
+        assert prompt is not None, (
+            f"MarkdownPromptParser could not parse Claude's generated template. "
+            f"Template content:\n{content}"
+        )
+        assert prompt.priority is not None
+
+    @llm_eval
+    def test_si006_claude_generated_add_command_submits_to_queue(
+        self, anthropic_client, skill_content, tmp_path
+    ):
+        """
+        SI-006: Claude generates a 'claude-queue add' command; when executed
+        against a temp storage directory, the job appears in the queue.
+
+        This is the end-to-end test: LLM output → shell command → queue file.
+        """
+        response = anthropic_client.messages.create(
+            model=_EVAL_MODEL,
+            max_tokens=256,
+            system=skill_content,
+            messages=[{
+                "role": "user",
+                "content": (
+                    f"Add a task to the queue to fix the login bug. "
+                    f"Use --working-dir {tmp_path}. "
+                    f"Output ONLY the claude-queue add command, nothing else."
+                ),
+            }],
+        )
+        text = response.content[0].text.strip()
+
+        # Accept commands inside a ```bash fence or as plain text.
+        bash_match = re.search(r"```(?:bash)?\n(claude-queue add.*?)```", text, re.DOTALL)
+        plain_match = re.search(r"claude-queue add\s+[^\n]+", text)
+        cmd_str = (
+            bash_match.group(1).strip()
+            if bash_match
+            else (plain_match.group(0) if plain_match else None)
+        )
+        assert cmd_str, (
+            f"Expected a 'claude-queue add ...' command in the response. "
+            f"Got: {text!r}"
+        )
+
+        # Replace 'claude-queue' with the Python module invocation so the command
+        # runs against the local source tree without needing an installed entry-point.
+        parts = shlex.split(cmd_str)
+        parts[0:1] = [sys.executable, "-m", "claude_code_queue.cli"]
+        parts += ["--storage-dir", str(tmp_path)]
+
+        import subprocess
+        result = subprocess.run(parts, capture_output=True, text=True)
+        assert result.returncode == 0, (
+            f"claude-queue add command failed.\n"
+            f"Command: {parts}\n"
+            f"stderr: {result.stderr}"
+        )
+
+        storage = QueueStorage(str(tmp_path))
+        state = storage.load_queue_state()
+        assert len(state.prompts) >= 1, (
+            "Expected at least one queued prompt after running the generated command."
+        )
+        assert state.prompts[0].status.value == "queued"


### PR DESCRIPTION
## Summary

- **Immediate cleanup** of JSONL, todo, debug, and telemetry artifacts when a rate-limited execution is detected — prevents thousands of junk files from accumulating during rate-limit windows
- **UUID correlation strategy**: identifies the rate-limited JSONL file by timestamp + size, extracts the session UUID, then deletes correlated files by direct path construction (no directory-wide globbing or size heuristics for debug files)
- **Resolved working directory stashed once** in `_execute_prompt()` to avoid a CWD mismatch bug when `working_directory` is relative (e.g. `"."`)

### Problem

When `claude --print` hits a rate limit, the subprocess still creates artifacts in four directories under `~/.claude/` (conversation logs, todo stubs, debug transcripts, telemetry events). The queue polls every 30s, so ~4,500 junk files accumulate per rate-limit window (~160 MB). The VSCode Claude Code extension tries to load all of these as conversation history, causing severe UI lag.

### Safety layers

| Artifact | Identification | Guard |
|---|---|---|
| JSONL | mtime >= last_executed AND size < 10 KB | Wide margin (rate-limited: 3–5 KB; successful: 100+ KB) |
| Todo | UUID correlation | Size <= 2 bytes (structurally exact `[]` stub) |
| Debug | UUID correlation | mtime >= last_executed (no size heuristic — gap too narrow) |
| Telemetry | UUID correlation via glob | — |

- Top-level try/except ensures cleanup failure never blocks state persistence
- Early `break` after first JSONL match (one subprocess = one UUID)

## Test plan

- [ ] Verify existing 542 tests still pass (confirmed locally)
- [ ] Unit tests for cleanup: fake files in temp dirs, verify only matching artifacts deleted
- [ ] Unit test: cleanup preserves files older than `last_executed` and large JSONL files
- [ ] Unit test: cleanup handles missing directories gracefully
- [ ] Unit test: cleanup exception doesn't break `_process_execution_result()` pipeline
- [ ] Integration test: run a prompt that rate-limits, verify no leftover artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)